### PR TITLE
Relay-based telemetry + create-dev-kit setup wizard (v0.6.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fullstack-dev-kit",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Issue-to-PR workflow kit for any tech stack. Fetch a user story from your tracker (Jira, Linear, GitHub Issues, Azure DevOps) and any linked Figma designs, implement with plan approval, enforce >95% coverage and a security pass, generate e2e tests, open the PR, fix review findings, and move the ticket to review.",
   "license": "Apache-2.0",
   "homepage": "https://github.com/theam/claude-dev-kit",
@@ -25,21 +25,9 @@
   "userConfig": {
     "telemetry_enabled": {
       "type": "boolean",
-      "title": "Share anonymous usage telemetry",
-      "description": "OFF by default. If enabled, at the end of sessions where the kit runs, it sends ANONYMOUS token counts (no prompts, code, file names, ticket content, emails, or org) to The Agile Monkeys' PostHog, to show aggregate impact. See TELEMETRY.md. Opt out any time with DEVKIT_TELEMETRY=0.",
+      "title": "Share anonymous usage telemetry (fallback toggle)",
+      "description": "OFF by default. Consent is normally set by the `npm create @theam/dev-kit` wizard (stored in ~/.claude/dev-kit-telemetry/config.json); this is a fallback toggle. When on, sessions where the kit runs send ANONYMOUS token counts to a relay (no key in the client, no prompts/code/paths/emails/org-instance/IP). See TELEMETRY.md. Hard off: DEVKIT_TELEMETRY=0.",
       "default": false,
-      "required": false
-    },
-    "posthog_api_key": {
-      "type": "string",
-      "title": "PostHog project API key (override)",
-      "description": "Optional. Leave empty to send to the maintainers' project. Set a phc_... key to send to your own PostHog instead. This is a write-only public key.",
-      "required": false
-    },
-    "posthog_host": {
-      "type": "string",
-      "title": "PostHog host (override)",
-      "description": "Optional. Defaults to https://eu.i.posthog.com. Set to https://us.i.posthog.com or your self-hosted PostHog URL if needed.",
       "required": false
     }
   }

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .env
 .DS_Store
+node_modules/
+.vercel/

--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ Give the `coding-agent` a user story ID from your tracker and it orchestrates th
    └─ issue-update        → comment PR link on the ticket + move it to review
 ```
 
+**Install in one command:**
+
+```bash
+npm create @theam/dev-kit
+```
+
+Interactive setup — tracker, Figma, telemetry consent, org — then it installs the plugin for you. Full options in [Installing in Claude Code](#installing-in-claude-code).
+
 ## Stack-agnostic by design
 
 The kit carries **no assumptions about language, framework, or test runner**. It reads everything stack-specific — build/test/lint/coverage commands, architecture conventions, and any implementer subagents — from the **consuming repo's `CLAUDE.md` and `.claude/`**, and detects conventions from the project when they aren't declared. Use it with .NET, Node, Python, Go, Rust, Java, or anything else.
@@ -35,41 +43,28 @@ It integrates with your tools through **adapters**, not hardcoded dependencies:
 
 The kit is a Claude Code **plugin**. Install it once per developer; it then loads in every session across every surface — the [CLI](https://code.claude.com), the desktop app, the VS Code / JetBrains extensions, and the web app (claude.ai/code).
 
-### Fastest: the setup wizard
+**Prerequisites:** [Claude Code](https://code.claude.com) (`claude --version`) and the [GitHub CLI](https://cli.github.com) authenticated (`gh auth status`).
+
+### Install with npm (recommended)
 
 ```bash
 npm create @theam/dev-kit
 ```
 
-Interactive: pick your issue tracker and whether you use Figma, review and opt in (or out of) anonymous telemetry, set your organisation, and it writes the config and runs the install commands for you. Everything below is the same thing done by hand.
+The wizard picks your issue tracker and whether you use Figma, **shows exactly what anonymous telemetry would be collected and lets you opt in or out**, sets your organisation label, writes `.claude/dev-kit.json`, and runs the plugin install for you. Then authorize your connectors (below) and you're done.
 
-**Prerequisites**
+### Manual install (what the wizard automates)
 
-- [Claude Code](https://code.claude.com) installed and signed in — verify with `claude --version`.
-- [GitHub CLI](https://cli.github.com) authenticated — verify with `gh auth status`.
-
-### 1. Add the marketplace and install the plugin
-
-Run these from a **terminal**. Plugin management is CLI-only — the VS Code / JetBrains chat panels reject `/plugin` commands.
+From a **terminal** — plugin management is CLI-only; the VS Code / JetBrains chat panels reject `/plugin` commands:
 
 ```bash
 claude plugin marketplace add theam/claude-dev-kit
 claude plugin install fullstack-dev-kit@claude-dev-kit
 ```
 
-This is **user-level and permanent**: every future session (CLI or IDE extension) loads the kit automatically — you never reinstall per session, per window, or per project.
+Installation is **user-level and permanent** — every future session (CLI or IDE extension) loads the kit automatically, no reinstall per session or project. Verify with `claude plugin list`, or type `/` in a session and search `fullstack-dev-kit:` (you should see `work-story`, `launch-story`, and the skills; agents show under `/agents`).
 
-### 2. Verify it loaded
-
-Start a session (`claude` in a terminal, or the IDE panel — reload the window if it was open during the install) and confirm the plugin is active:
-
-```bash
-claude plugin list          # fullstack-dev-kit should appear as installed + enabled
-```
-
-In a session, type `/` and search for `fullstack-dev-kit:` — you should see `work-story`, `launch-story`, and the skills. (Agents don't appear in that list; `/agents` shows them.)
-
-### 3. Authorize the connectors your team uses (one-time)
+### Authorize the connectors your team uses (one-time)
 
 Run `/mcp` in a session, or use your claude.ai connector settings:
 
@@ -83,7 +78,7 @@ Run `/mcp` in a session, or use your claude.ai connector settings:
 
 > When authorizing an MCP via OAuth, complete the browser flow **immediately** — the link is tied to a live local callback and expires with it. Don't reuse old tabs or restart the session mid-flow.
 
-### 4. Enable auto-update
+### Enable auto-update
 
 `/plugin` → **Marketplaces** tab → `claude-dev-kit` → **Enable auto-update**. New versions then arrive at session startup. To pull manually instead:
 

--- a/README.md
+++ b/README.md
@@ -66,15 +66,21 @@ Installation is **user-level and permanent** — every future session (CLI or ID
 
 ### Authorize the connectors your team uses (one-time)
 
-Run `/mcp` in a session, or use your claude.ai connector settings:
+The plugin **declares** the tracker/design MCP servers (`atlassian`, `linear`, `figma`) — you don't add them by hand, you just **authorize** the ones you use. Three ways, pick whichever fits:
 
-| Tool | Connector | Auth |
+- **In a Claude Code session** (CLI, IDE panel, or the Desktop app's Code tab): run `/mcp`, pick the server (e.g. `atlassian`), and complete the OAuth in the browser.
+- **From the terminal:** `claude mcp login atlassian` (and `claude mcp list` to check status — plugin-declared servers show ⏸ *pending approval* until first approved inside a session).
+- **Already connected in Claude Desktop?** Import those connectors into Claude Code with `claude mcp add-from-claude-desktop` (macOS/WSL).
+
+| Tool | Connector | Authorize with |
 |---|---|---|
-| Jira | `atlassian` MCP | `/mcp` → OAuth |
-| Linear | `linear` MCP | `/mcp` → OAuth |
+| Jira | `atlassian` MCP | `/mcp` · `claude mcp login atlassian` |
+| Linear | `linear` MCP | `/mcp` · `claude mcp login linear` |
 | GitHub Issues | — (uses `gh`) | `gh auth login` |
 | Azure DevOps | — (uses `az`) | `az login` |
-| Figma *(optional)* | `figma` MCP | `/mcp` → OAuth |
+| Figma *(optional)* | `figma` MCP | `/mcp` · `claude mcp login figma` |
+
+Authorization is **per developer, one-time** — it persists across sessions. The kit then discovers the rest (Jira site, project key, field IDs) automatically on first use via `dev-kit-setup`.
 
 > When authorizing an MCP via OAuth, complete the browser flow **immediately** — the link is tied to a live local callback and expires with it. Don't reuse old tabs or restart the session mid-flow.
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ It integrates with your tools through **adapters**, not hardcoded dependencies:
 
 The kit is a Claude Code **plugin**. Install it once per developer; it then loads in every session across every surface — the [CLI](https://code.claude.com), the desktop app, the VS Code / JetBrains extensions, and the web app (claude.ai/code).
 
+### Fastest: the setup wizard
+
+```bash
+npm create @theam/dev-kit
+```
+
+Interactive: pick your issue tracker and whether you use Figma, review and opt in (or out of) anonymous telemetry, set your organisation, and it writes the config and runs the install commands for you. Everything below is the same thing done by hand.
+
 **Prerequisites**
 
 - [Claude Code](https://code.claude.com) installed and signed in — verify with `claude --version`.
@@ -181,7 +189,7 @@ Adding a tracker, PR host, or design tool is an **adapter**, not a rewrite — s
 
 ## Telemetry (anonymous, opt-in, OFF by default)
 
-The kit can share **anonymous token counts** to [PostHog](https://posthog.com) so the maintainers can show aggregate impact. It is **off by default** and sends **only** when a developer enables it (`telemetry_enabled`). Events are anonymous (a random `installId`, no person profile); it never sends prompts, code, file names, ticket contents, emails, or org — and only counts sessions where the kit actually ran. The whole implementation is one auditable file, [`scripts/telemetry.mjs`](./scripts/telemetry.mjs). Kill switch: `DEVKIT_TELEMETRY=0`. It runs in the CLI, the IDE extensions, and the Desktop app's **Code tab** (local/SSH sessions), and needs Node on `PATH` (restart the desktop app if it can't find Node). Full details and the exact payload: **[TELEMETRY.md](./TELEMETRY.md)**.
+The kit can share **anonymous token counts** so the maintainers can show aggregate impact. It is **off by default**; you opt in via the setup wizard (`npm create @theam/dev-kit`). Clients ship **no API key** and never call analytics directly — they POST to a [relay](./packages/telemetry-relay/) that re-enforces a [machine-readable contract](./telemetry/contract.v1.json) and strips your IP before forwarding to PostHog. Events are anonymous (a random `install_id`); never prompts, code, file names, ticket contents, emails, or org-instance data — and only sessions where the kit actually ran. Kill switch: `DEVKIT_TELEMETRY=0`. Runs in the CLI, IDE extensions, and the Desktop app's **Code tab** (needs Node on `PATH`). Full details and the exact payload: **[TELEMETRY.md](./TELEMETRY.md)**.
 
 ## Troubleshooting
 

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -1,50 +1,56 @@
 # Telemetry
 
-claude-dev-kit can send **anonymous, opt-in** usage telemetry to [PostHog](https://posthog.com) so The Agile Monkeys can show aggregate impact (e.g. "teams using this kit drove *N* tokens of Claude usage"). This document is the complete, honest description of what that means. If anything here surprises you, telemetry is doing something it shouldn't — open an issue.
+claude-dev-kit can share **anonymous, opt-in** usage telemetry so The Agile Monkeys can show aggregate impact (e.g. "teams using this kit drove *N* tokens of Claude usage"). This document is the complete, honest description. If anything here surprises you, telemetry is doing something it shouldn't — open an issue.
 
 ## The short version
 
-- **OFF by default.** Nothing is sent unless you explicitly turn it on.
-- **Anonymous.** Sent as a PostHog anonymous event (`$process_person_profile: false`), identified only by a random `installId`. No person profile is created; no account, email, org, or repo is attached.
-- **Token counts only.** It reports how *many* tokens a session used — never *what* was in them.
-- **Honest attribution.** It only reports sessions where a kit command/agent actually ran, so we never claim usage the kit didn't drive.
-- **Auditable.** The entire implementation is one readable file: [`scripts/telemetry.mjs`](./scripts/telemetry.mjs).
+- **OFF by default.** Nothing is sent unless you explicitly opt in.
+- **Anonymous.** Identified only by a random `install_id`. No account, email, org-instance, or repo is attached.
+- **Token counts only.** How *many* tokens a session used — never *what* was in them.
+- **No key in the client, no direct PostHog call.** Clients POST to a relay that re-enforces the contract and strips your IP before forwarding.
+- **Honest attribution.** Only sessions where a kit command/agent actually ran are reported.
+- **Auditable.** Client: [`scripts/telemetry.mjs`](./scripts/telemetry.mjs). Contract: [`telemetry/contract.v1.json`](./telemetry/contract.v1.json). Relay: [`packages/telemetry-relay/`](./packages/telemetry-relay/).
 
-## How to enable it
+## How to enable / disable it
 
-Set `telemetry_enabled` = `true` (per developer, in `~/.claude/settings.json`) when you enable the plugin (Claude Code prompts for `userConfig`), or later via `/plugin` → plugin settings. That's it — the destination (The Agile Monkeys' PostHog project) is built in.
+The easy path is the setup wizard:
 
-To send to **your own** PostHog instead, also set `posthog_api_key` (a `phc_...` project key) and optionally `posthog_host`.
+```bash
+npm create @theam/dev-kit
+```
 
-## How to disable it
+It shows exactly what would be collected and asks yes/no, writing your choice to `~/.claude/dev-kit-telemetry/config.json` (per user). To change your mind, re-run it, or:
 
-Any one of these stops all sending:
+- **Disable:** `DEVKIT_TELEMETRY=0` (wins over everything), or set `"consent": "denied"` in that file.
+- **Enable without the wizard:** set `"consent": "granted"` there, or the plugin's `telemetry_enabled` option.
 
-- Set the env var `DEVKIT_TELEMETRY=0` (wins over everything).
-- Set `telemetry_enabled` to `false`.
+## The relay boundary
 
-## Where it runs
+Clients **never talk to PostHog directly and ship no PostHog key.** They send the sanitized event to the relay ([`packages/telemetry-relay/`](./packages/telemetry-relay/)), which:
 
-The telemetry hook runs wherever Claude Code runs the kit's plugin: the CLI, the IDE extensions, and the **Code tab of the Claude Desktop app** (local and SSH sessions). It does **not** run in the desktop app's Chat/Cowork tabs (those aren't Claude Code), nor in cloud or WSL sessions (plugins are unavailable there).
+1. Rejects anything that isn't the expected event.
+2. **Re-enforces `contract.v1.json`** — drops every property not in the contract, validates enums and bounds.
+3. **Never reads or stores your IP.**
+4. Forwards to PostHog as an anonymous event, using a key held only in the relay's environment.
 
-Because the hook runs `node`, Node.js must be on `PATH`. The desktop app only extracts `PATH` from your shell profile at launch (macOS) or from system environment variables (Windows) — so if Node was installed after the app started, or isn't on that PATH, the hook simply no-ops. Restart the desktop app to reload the environment. None of this affects the rest of the kit.
+This mirrors the relay pattern used by [theam/limina](https://github.com/theam/limina).
 
 ## Exactly what is sent
 
-A single PostHog `/capture/` POST at `SessionEnd`, only for sessions where the kit ran:
+One POST at `SessionEnd`, only for sessions where the kit ran, matching the contract:
 
 ```json
 {
-  "api_key": "phc_...(write-only public key)",
-  "event": "kit_session_completed",
-  "distinct_id": "b1c3f0a2-...-random-uuid",
+  "schema_version": 1,
+  "event_name": "kit_session_completed",
+  "install_id": "b1c3f0a2-…-random-uuid",
+  "org": "acme-corp (only if self-declared — omitted otherwise)",
   "properties": {
-    "$process_person_profile": false,
-    "schema": 1,
-    "kit_version": "0.5.0",
+    "kit_version": "0.6.0",
     "claude_code_version": "2.1.x",
     "os": "darwin",
     "tracker_type": "jira",
+    "duration_bucket": "5m_to_15m",
     "tokens_input": 48210,
     "tokens_output": 9134,
     "tokens_cache_read": 120400,
@@ -54,39 +60,35 @@ A single PostHog `/capture/` POST at `SessionEnd`, only for sessions where the k
 }
 ```
 
-- `distinct_id` — a random UUID generated once and stored at `~/.claude/dev-kit-telemetry-id`. Not derived from your machine, user, or repo. Delete that file to reset it.
-- `tracker_type` — the *category* of tracker (jira / linear / github / azure), never the site, project, or instance.
-- `org` — **present only if your organisation opted in to company attribution** (see below). Absent otherwise.
+- `install_id` — random UUID stored at `~/.claude/dev-kit-telemetry/config.json`. Not derived from your machine, user, or repo. Delete the file to reset.
+- `tracker_type` — the *category* (jira / linear / github / azure), never the site, project, or instance.
+- `duration_bucket` — a coarse range, never a raw timestamp.
 - `tokens_*` — sums parsed from the session transcript's `usage` fields.
+
+## What is NEVER sent
+
+Prompts, responses, code, diffs, file paths, file names, repo names or URLs, ticket keys or contents, commit messages, branch names, emails, usernames, organization-instance data, or your IP (stripped at the relay). The client reads the transcript **only** to sum token counts and to check whether a kit component ran.
 
 ## Company attribution (optional, organisation-level)
 
-By default events are attributed only to a random `installId` — the maintainers see *how many* tokens the kit drove, not *whose*. An organisation that wants its own usage attributed to it can set a self-declared label in the committed `.claude/dev-kit.json`:
+By default events carry only a random `install_id`. An organisation that wants its own usage attributed to it sets a self-declared label in the committed `.claude/dev-kit.json` (the wizard can do this):
 
 ```json
 { "telemetry": { "org": "acme-corp" } }
 ```
 
-When present, it is sent as the `org` property (and a PostHog `company` group). It is **off unless you add it**.
+When present it is sent as `org` (and a PostHog `company` group). Off unless you add it.
 
 Why this is GDPR-safe done this way:
 
 - **It identifies a company, not a person.** GDPR protects natural persons; an organisation label is not personal data on its own.
-- **It is self-declared by the organisation**, committed deliberately to the repo — not derived from any individual signal. The kit **never** reads git author, email, username, or remote URL to guess the company. Doing so would turn organisation data back into personal data.
-- **Keep it a company name/code**, not a person. Do not use a one-person label that names an individual; for very small orgs a company label can indirectly identify someone — use judgement and, if in doubt, don't set it.
-- Combined with an anonymous `installId` it stays company-level; the maintainers never receive an individual identity.
+- **It is self-declared by the organisation** — never derived from git author, email, username, or remote URL (doing so would turn it back into personal data).
+- **Keep it a company name/code**, not a person. For very small / one-person orgs a company label can indirectly identify someone — use judgement, and if in doubt don't set it.
 
-> This keeps you on the safe side of B2B usage analytics, but company data can edge into personal data for sole traders / one-person orgs. Confirm your specific setup with counsel before relying on it.
+> This keeps you on the safe side of B2B usage analytics, but confirm your specific setup with counsel before relying on it.
 
-## What is NEVER sent
+## For maintainers (running the relay + PostHog)
 
-Prompts, responses, code, diffs, file paths, file names, repo names or URLs, ticket keys or contents, commit messages, branch names, emails, usernames, organization names, or the session id. The script reads the transcript **only** to sum token counts and to check whether a kit component ran — it never transmits any content from it.
-
-## For maintainers (running the PostHog project)
-
-- **Set the key before release.** Put your PostHog project API key in `DEFAULT_POSTHOG_KEY` in [`scripts/telemetry.mjs`](./scripts/telemetry.mjs) (replacing `__THEAM_POSTHOG_PROJECT_KEY__`). Until then, telemetry no-ops even if a user opts in. The key is write-only/public, so committing it is expected and safe.
-- **Host = EU by default** (`https://eu.i.posthog.com`) to keep data in the EU. Change the default only deliberately.
-- **Disable IP capture** in PostHog project settings (*Project → Data collection → Discard client IP data*). PostHog geolocates by request IP by default; an IP plus `installId` is re-identifiable, which would undo anonymity.
-- Report only **aggregates** externally (including to Anthropic). Because the data is anonymous by construction, there is no per-user record to delete on request — state that in any privacy notice rather than promising deletion you can't perform.
-
-> Consult counsel before enabling collection for EU users: even anonymous telemetry becomes personal data if it can be re-identified. This kit keeps the payload minimal and the events anonymous specifically to stay on the safe side, but the PostHog project's configuration (IP capture, retention) is where that guarantee is kept or lost.
+- Deploy [`packages/telemetry-relay/`](./packages/telemetry-relay/) and set `POSTHOG_API_KEY` (+ optional `POSTHOG_HOST`, default EU) in its environment. Then point `default_relay_url` in [`telemetry/contract.v1.json`](./telemetry/contract.v1.json) at the deployment (keep the relay package's copy in sync).
+- Disable IP capture in PostHog and access logs on the relay host — an IP plus `install_id` is re-identifiable.
+- Report only **aggregates** externally (including to Anthropic). The data is anonymous by construction, so there is no per-user record to delete on request — state that in any privacy notice.

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -56,7 +56,27 @@ A single PostHog `/capture/` POST at `SessionEnd`, only for sessions where the k
 
 - `distinct_id` — a random UUID generated once and stored at `~/.claude/dev-kit-telemetry-id`. Not derived from your machine, user, or repo. Delete that file to reset it.
 - `tracker_type` — the *category* of tracker (jira / linear / github / azure), never the site, project, or instance.
+- `org` — **present only if your organisation opted in to company attribution** (see below). Absent otherwise.
 - `tokens_*` — sums parsed from the session transcript's `usage` fields.
+
+## Company attribution (optional, organisation-level)
+
+By default events are attributed only to a random `installId` — the maintainers see *how many* tokens the kit drove, not *whose*. An organisation that wants its own usage attributed to it can set a self-declared label in the committed `.claude/dev-kit.json`:
+
+```json
+{ "telemetry": { "org": "acme-corp" } }
+```
+
+When present, it is sent as the `org` property (and a PostHog `company` group). It is **off unless you add it**.
+
+Why this is GDPR-safe done this way:
+
+- **It identifies a company, not a person.** GDPR protects natural persons; an organisation label is not personal data on its own.
+- **It is self-declared by the organisation**, committed deliberately to the repo — not derived from any individual signal. The kit **never** reads git author, email, username, or remote URL to guess the company. Doing so would turn organisation data back into personal data.
+- **Keep it a company name/code**, not a person. Do not use a one-person label that names an individual; for very small orgs a company label can indirectly identify someone — use judgement and, if in doubt, don't set it.
+- Combined with an anonymous `installId` it stays company-level; the maintainers never receive an individual identity.
+
+> This keeps you on the safe side of B2B usage analytics, but company data can edge into personal data for sole traders / one-person orgs. Confirm your specific setup with counsel before relying on it.
 
 ## What is NEVER sent
 

--- a/packages/create-dev-kit/index.mjs
+++ b/packages/create-dev-kit/index.mjs
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+/*
+ * create-dev-kit — interactive setup for the claude-dev-kit plugin.
+ *
+ * Zero dependencies (only Node built-ins) so it is trivial to audit before you
+ * run it via `npm create @theam/dev-kit`. It writes two files:
+ *   - <repo>/.claude/dev-kit.json           (tracker choice, figma flag, org label)
+ *   - ~/.claude/dev-kit-telemetry/config.json  (your telemetry consent — per user)
+ * and can run the plugin install commands for you. It never sends anything itself.
+ */
+import { createInterface } from 'node:readline/promises';
+import { stdin, stdout, exit } from 'node:process';
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { homedir } from 'node:os';
+import { randomUUID } from 'node:crypto';
+import { spawnSync } from 'node:child_process';
+
+const rl = createInterface({ input: stdin, output: stdout });
+const b = (s) => `\x1b[1m${s}\x1b[0m`;
+const dim = (s) => `\x1b[2m${s}\x1b[0m`;
+
+async function ask(q, def) {
+  const a = (await rl.question(`${q}${def ? dim(` (${def})`) : ''} `)).trim();
+  return a || def || '';
+}
+async function yn(q, def = true) {
+  const a = (await ask(`${q} ${def ? '[Y/n]' : '[y/N]'}`)).toLowerCase();
+  if (!a) return def;
+  return a.startsWith('y');
+}
+function mergeJson(path, patch) {
+  let cur = {};
+  if (existsSync(path)) { try { cur = JSON.parse(readFileSync(path, 'utf8')); } catch { cur = {}; } }
+  const next = { ...cur, ...patch };
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(next, null, 2) + '\n');
+  return next;
+}
+
+async function main() {
+  console.log(`\n${b('claude-dev-kit setup')}\n${dim('Issue-to-PR workflow plugin for Claude Code — by The Agile Monkeys')}\n`);
+
+  // 1. Issue tracker
+  console.log(b('1. Issue tracker'));
+  const trackers = { 1: 'jira', 2: 'linear', 3: 'github', 4: 'azure', 5: null };
+  console.log('   1) Jira   2) Linear   3) GitHub Issues   4) Azure DevOps   5) None');
+  let tChoice = await ask('   Which tracker does this repo use?', '1');
+  const tracker = trackers[tChoice] ?? 'jira';
+
+  // 2. Figma
+  console.log(`\n${b('2. Design')}`);
+  const figma = await yn('   Will you link Figma designs in tickets?', false);
+
+  // 3. Telemetry — informed consent
+  console.log(`\n${b('3. Anonymous usage telemetry')} ${dim('(optional)')}`);
+  console.log(dim(
+    '   If you opt in, at the end of sessions where the kit runs it sends, to\n' +
+    '   The Agile Monkeys via a relay:\n' +
+    '     • token counts, a coarse session-duration bucket\n' +
+    '     • kit version, Claude Code version, OS, tracker category\n' +
+    '     • a random install id (no account, email, or machine data)\n' +
+    "   It NEVER sends prompts, code, file names, repo names, ticket content,\n" +
+    '   emails, org-instance data, or your IP (stripped at the relay).\n' +
+    '   Off unless you say yes. Details: TELEMETRY.md. Turn off later: DEVKIT_TELEMETRY=0.'
+  ));
+  const consent = await yn('   Share anonymous usage telemetry?', false);
+
+  // 4. Organisation label (only meaningful if telemetry is on)
+  let org = '';
+  if (consent) {
+    console.log(`\n${b('4. Organisation')} ${dim('(optional — attributes your usage to your company, not a person)')}`);
+    org = await ask('   Organisation label to tag your usage (leave empty to stay unattributed):', '');
+  }
+
+  // --- Write repo config ---------------------------------------------------
+  const repoCfgPath = join(process.cwd(), '.claude', 'dev-kit.json');
+  const repoPatch = { figma };
+  if (tracker) repoPatch.tracker = { type: tracker };
+  if (org.trim()) repoPatch.telemetry = { org: org.trim().slice(0, 64) };
+  mergeJson(repoCfgPath, repoPatch);
+
+  // --- Write per-user telemetry consent ------------------------------------
+  const consentPath = join(homedir(), '.claude', 'dev-kit-telemetry', 'config.json');
+  let installId = randomUUID();
+  if (existsSync(consentPath)) {
+    try { installId = JSON.parse(readFileSync(consentPath, 'utf8')).install_id || installId; } catch { /* ignore */ }
+  }
+  mergeJson(consentPath, {
+    schema_version: 1,
+    consent: consent ? 'granted' : 'denied',
+    install_id: installId,
+  });
+
+  // --- Report + offer to install ------------------------------------------
+  console.log(`\n${b('Done.')}`);
+  console.log(`  • ${repoCfgPath} ${dim('(commit this — shared by your team)')}`);
+  console.log(`  • ${consentPath} ${dim('(per-user, private — telemetry ' + (consent ? 'ON' : 'OFF') + ')')}`);
+
+  if (await yn('\nInstall the plugin now with the Claude CLI?', true)) {
+    for (const args of [
+      ['plugin', 'marketplace', 'add', 'theam/claude-dev-kit'],
+      ['plugin', 'install', 'fullstack-dev-kit@claude-dev-kit'],
+    ]) {
+      console.log(dim(`  $ claude ${args.join(' ')}`));
+      const r = spawnSync('claude', args, { stdio: 'inherit' });
+      if (r.error) {
+        console.log(`  ${dim('claude CLI not found — run these two commands yourself:')}`);
+        console.log('    claude plugin marketplace add theam/claude-dev-kit');
+        console.log('    claude plugin install fullstack-dev-kit@claude-dev-kit');
+        break;
+      }
+    }
+  } else {
+    console.log(dim('\n  Install later with:'));
+    console.log('    claude plugin marketplace add theam/claude-dev-kit');
+    console.log('    claude plugin install fullstack-dev-kit@claude-dev-kit');
+  }
+  console.log(`\n${dim('Restart your Claude session, then run')} ${b('/fullstack-dev-kit:work-story <TICKET>')}\n`);
+}
+
+main().catch((e) => { console.error(e?.message || e); exit(1); }).finally(() => rl.close());

--- a/packages/create-dev-kit/index.mjs
+++ b/packages/create-dev-kit/index.mjs
@@ -44,7 +44,11 @@ async function main() {
   // 1. Issue tracker
   console.log(b('1. Issue tracker'));
   const trackers = { 1: 'jira', 2: 'linear', 3: 'github', 4: 'azure', 5: null };
-  console.log('   1) Jira   2) Linear   3) GitHub Issues   4) Azure DevOps   5) None');
+  console.log('   1) Jira');
+  console.log('   2) Linear');
+  console.log('   3) GitHub Issues');
+  console.log('   4) Azure DevOps');
+  console.log('   5) None');
   let tChoice = await ask('   Which tracker does this repo use?', '1');
   const tracker = trackers[tChoice] ?? 'jira';
 

--- a/packages/create-dev-kit/index.mjs
+++ b/packages/create-dev-kit/index.mjs
@@ -52,6 +52,14 @@ async function main() {
   let tChoice = await ask('   Which tracker does this repo use?', '1');
   const tracker = trackers[tChoice] ?? 'jira';
 
+  const TRACKER_HINT = {
+    jira: 'To connect Jira, authorize the Atlassian MCP after installing:\n     • in a Claude Code session: /mcp → authorize "atlassian"\n     • or from the terminal: claude mcp login atlassian\n     • already connected in Claude Desktop? claude mcp add-from-claude-desktop',
+    linear: 'To connect Linear, authorize the Linear MCP after installing:\n     • /mcp → authorize "linear"   (or: claude mcp login linear)',
+    github: 'To connect GitHub Issues, just authenticate the GitHub CLI:\n     • gh auth login   (no MCP needed)',
+    azure: 'To connect Azure DevOps, authenticate the Azure CLI:\n     • az login   (no MCP needed)',
+  };
+  if (TRACKER_HINT[tracker]) console.log(dim('   → ' + TRACKER_HINT[tracker]));
+
   // 2. Figma
   console.log(`\n${b('2. Design')}`);
   const figma = await yn('   Will you link Figma designs in tickets?', false);

--- a/packages/create-dev-kit/package.json
+++ b/packages/create-dev-kit/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@theam/create-dev-kit",
+  "version": "0.1.0",
+  "description": "Interactive setup for the claude-dev-kit Claude Code plugin: pick your issue tracker and design tool, review and opt in (or out) of anonymous telemetry, set your organisation, and write the config.",
+  "license": "Apache-2.0",
+  "type": "module",
+  "bin": { "create-dev-kit": "index.mjs" },
+  "files": ["index.mjs"],
+  "engines": { "node": ">=18" },
+  "homepage": "https://github.com/theam/claude-dev-kit",
+  "repository": { "type": "git", "url": "https://github.com/theam/claude-dev-kit.git", "directory": "packages/create-dev-kit" },
+  "keywords": ["claude", "claude-code", "dev-kit", "scaffold", "setup"]
+}

--- a/packages/telemetry-relay/README.md
+++ b/packages/telemetry-relay/README.md
@@ -13,6 +13,12 @@ This mirrors the relay pattern used by [theam/limina](https://github.com/theam/l
 
 ## Deploy (Vercel)
 
+This lives inside the `claude-dev-kit` monorepo and deploys **from this subdirectory** — no separate repo needed.
+
+**Dashboard:** New Project → import `theam/claude-dev-kit` → set **Root Directory = `packages/telemetry-relay`** → deploy. Vercel serves `api/ingest.js` at `/api/ingest` (the path the kit posts to), and `vercel.json` bundles `contract.v1.json` alongside the function.
+
+**CLI:**
+
 ```bash
 cd packages/telemetry-relay
 vercel deploy --prod

--- a/packages/telemetry-relay/README.md
+++ b/packages/telemetry-relay/README.md
@@ -1,0 +1,42 @@
+# claude-dev-kit telemetry relay
+
+A tiny serverless relay between the kit's clients and PostHog. Clients never hold
+a PostHog key and never call PostHog directly — they POST a sanitized event here,
+and the relay:
+
+1. Rejects anything that isn't the expected `kit_session_completed` event.
+2. **Re-enforces `contract.v1.json`** — drops every property not in the contract, validates enums and integer bounds.
+3. **Never reads or stores the caller IP.**
+4. Forwards the accepted event to PostHog as an anonymous event, using a key held only in this server's environment.
+
+This mirrors the relay pattern used by [theam/limina](https://github.com/theam/limina), with its own contract and its own PostHog project.
+
+## Deploy (Vercel)
+
+```bash
+cd packages/telemetry-relay
+vercel deploy --prod
+```
+
+Set the environment variables in the Vercel project:
+
+| Var | Required | Default | Notes |
+|---|---|---|---|
+| `POSTHOG_API_KEY` | yes | — | PostHog project API key (write-only/public). Held only here, never shipped to clients. |
+| `POSTHOG_HOST` | no | `https://eu.i.posthog.com` | Use EU cloud to keep data in the EU. |
+
+Until `POSTHOG_API_KEY` is set the relay responds `503 relay_not_configured` and forwards nothing.
+
+Then point the kit at it: set `default_relay_url` in `telemetry/contract.v1.json` (repo root) to this deployment's URL, and keep this package's `contract.v1.json` copy in sync.
+
+## Privacy guarantees
+
+- IP is never forwarded or logged (disable Vercel access logs / PostHog IP capture too).
+- Only the contract's allowlisted properties survive; unknown fields are silently dropped.
+- `distinct_id` is the client's random `install_id`; `org` is included only if the organisation self-declared it.
+
+## Local check
+
+```bash
+POSTHOG_API_KEY=phc_test node -e "import('./api/ingest.js').then(m=>console.log('loaded', typeof m.default))"
+```

--- a/packages/telemetry-relay/api/ingest.js
+++ b/packages/telemetry-relay/api/ingest.js
@@ -16,7 +16,17 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const contract = JSON.parse(readFileSync(join(__dirname, '..', 'contract.v1.json'), 'utf8'));
+
+// Load the contract from whichever location survives serverless bundling.
+// (vercel.json `includeFiles` bundles contract.v1.json alongside the function.)
+let contract = null;
+for (const p of [
+  join(__dirname, '..', 'contract.v1.json'),
+  join(__dirname, 'contract.v1.json'),
+  join(process.cwd(), 'contract.v1.json'),
+]) {
+  try { contract = JSON.parse(readFileSync(p, 'utf8')); break; } catch { /* try next */ }
+}
 
 const POSTHOG_HOST = (process.env.POSTHOG_HOST || 'https://eu.i.posthog.com').replace(/\/+$/, '');
 const POSTHOG_API_KEY = process.env.POSTHOG_API_KEY || '';
@@ -50,6 +60,7 @@ export default async function handler(req, res) {
   if (req.method === 'OPTIONS') return res.status(204).end();
   if (req.method !== 'POST') return res.status(405).json({ error: 'method_not_allowed' });
   if (!POSTHOG_API_KEY) return res.status(503).json({ error: 'relay_not_configured' });
+  if (!contract) return res.status(503).json({ error: 'contract_unavailable' });
 
   let body = req.body;
   try { if (typeof body === 'string') body = JSON.parse(body); } catch { body = null; }

--- a/packages/telemetry-relay/api/ingest.js
+++ b/packages/telemetry-relay/api/ingest.js
@@ -1,0 +1,91 @@
+// Telemetry relay for claude-dev-kit.
+//
+// Clients never talk to PostHog directly. They POST a sanitized event here; the
+// relay RE-ENFORCES telemetry/contract.v1.json (drops any unknown property,
+// validates enums/ranges), never stores the caller IP, and forwards the accepted
+// event to PostHog using a key held only in this server's environment.
+//
+// Deploy on Vercel (or any Node serverless host). Required env:
+//   POSTHOG_API_KEY   PostHog project API key (write-only/public is fine)
+//   POSTHOG_HOST      e.g. https://eu.i.posthog.com   (default: EU cloud)
+//
+// This mirrors the relay pattern used by theam/limina, with its own contract.
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const contract = JSON.parse(readFileSync(join(__dirname, '..', 'contract.v1.json'), 'utf8'));
+
+const POSTHOG_HOST = (process.env.POSTHOG_HOST || 'https://eu.i.posthog.com').replace(/\/+$/, '');
+const POSTHOG_API_KEY = process.env.POSTHOG_API_KEY || '';
+
+function sanitize(properties = {}) {
+  const spec = contract.allowed_properties;
+  const out = {};
+  for (const [key, def] of Object.entries(spec)) {
+    const v = properties[key];
+    if (v === undefined || v === null) continue;
+    if (def.const !== undefined && v !== def.const) continue;
+    if (def.type === 'integer') {
+      if (!Number.isFinite(v)) continue;
+      let n = Math.trunc(v);
+      if (def.min !== undefined && n < def.min) continue;
+      out[key] = n;
+    } else if (def.type === 'enum') {
+      if (def.values.includes(v)) out[key] = v;
+    } else if (def.type === 'string') {
+      if (typeof v === 'string') out[key] = v.slice(0, def.maxLength || 256);
+    } else if (def.type === 'version') {
+      if (typeof v === 'string' && /^[0-9][0-9A-Za-z.\-+]{0,31}$/.test(v)) out[key] = v;
+    }
+  }
+  // Everything not in the contract is dropped by construction.
+  return out;
+}
+
+export default async function handler(req, res) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  if (req.method === 'OPTIONS') return res.status(204).end();
+  if (req.method !== 'POST') return res.status(405).json({ error: 'method_not_allowed' });
+  if (!POSTHOG_API_KEY) return res.status(503).json({ error: 'relay_not_configured' });
+
+  let body = req.body;
+  try { if (typeof body === 'string') body = JSON.parse(body); } catch { body = null; }
+  if (!body || body.event_name !== contract.event_name) {
+    return res.status(400).json({ error: 'bad_event' });
+  }
+
+  const installId = typeof body.install_id === 'string' ? body.install_id.slice(0, 64) : null;
+  if (!installId) return res.status(400).json({ error: 'missing_install_id' });
+
+  const properties = sanitize(body.properties);
+  properties.$process_person_profile = false; // anonymous: no PostHog person profile
+  const org = typeof body.org === 'string' && body.org.trim() ? body.org.trim().slice(0, 64) : undefined;
+  if (org) properties.org = org;
+
+  const phEvent = {
+    api_key: POSTHOG_API_KEY,
+    event: contract.event_name,
+    distinct_id: installId,
+    // NOTE: the caller IP is never read, forwarded, or stored by this relay.
+    properties,
+    ...(org ? { $groups: { company: org } } : {}),
+  };
+
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 4000);
+    const r = await fetch(`${POSTHOG_HOST}/capture/`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(phEvent),
+      signal: controller.signal,
+    });
+    clearTimeout(timer);
+    return res.status(r.ok ? 202 : 502).json({ accepted: r.ok });
+  } catch {
+    return res.status(502).json({ accepted: false });
+  }
+}

--- a/packages/telemetry-relay/contract.v1.json
+++ b/packages/telemetry-relay/contract.v1.json
@@ -1,0 +1,32 @@
+{
+  "schema_version": 1,
+  "event_name": "kit_session_completed",
+  "default_relay_url": "https://claude-dev-kit-telemetry.vercel.app",
+  "duration_buckets": ["lt_1m", "1m_to_5m", "5m_to_15m", "15m_to_1h", "gte_1h"],
+  "allowed_properties": {
+    "schema_version": { "type": "integer", "const": 1 },
+    "kit_version": { "type": "version" },
+    "claude_code_version": { "type": "version", "optional": true },
+    "os": { "type": "enum", "values": ["darwin", "linux", "win32"] },
+    "tracker_type": { "type": "enum", "values": ["jira", "linear", "github", "azure"], "optional": true },
+    "org": { "type": "string", "maxLength": 64, "optional": true },
+    "duration_bucket": { "type": "enum", "values": ["lt_1m", "1m_to_5m", "5m_to_15m", "15m_to_1h", "gte_1h"], "optional": true },
+    "tokens_input": { "type": "integer", "min": 0 },
+    "tokens_output": { "type": "integer", "min": 0 },
+    "tokens_cache_read": { "type": "integer", "min": 0 },
+    "tokens_cache_creation": { "type": "integer", "min": 0 },
+    "tokens_total": { "type": "integer", "min": 0 }
+  },
+  "identity": {
+    "distinct_id": "random per-install UUID (install_id) — not derived from any personal or machine attribute",
+    "group": { "type": "company", "key": "org", "note": "present only if the organisation self-declared an org label" }
+  },
+  "never_collected": [
+    "prompts, responses, code, diffs",
+    "file paths, file names, repo names or URLs",
+    "ticket keys or contents, commit messages, branch names",
+    "emails, usernames, personal names",
+    "raw tool input/output, command arguments, stack traces",
+    "client IP (stripped at the relay, never stored)"
+  ]
+}

--- a/packages/telemetry-relay/package.json
+++ b/packages/telemetry-relay/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@theam/claude-dev-kit-telemetry-relay",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Telemetry relay for claude-dev-kit: re-enforces the contract, strips caller IP, forwards anonymous events to PostHog. Deploy on Vercel.",
+  "license": "Apache-2.0",
+  "engines": { "node": ">=18" }
+}

--- a/packages/telemetry-relay/vercel.json
+++ b/packages/telemetry-relay/vercel.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "functions": {
+    "api/ingest.js": {
+      "includeFiles": "contract.v1.json"
+    }
+  }
+}

--- a/scripts/telemetry.mjs
+++ b/scripts/telemetry.mjs
@@ -91,11 +91,17 @@ try {
     try { writeFileSync(idFile, installId); } catch { /* ignore */ }
   }
 
-  // --- Coarse category only: which tracker adapter (never the instance) ----
-  let trackerType;
+  // --- Coarse category + self-declared org label (never auto-derived) ------
+  // `tracker.type` is the adapter category (never the instance).
+  // `telemetry.org` is an ORGANISATION label the team sets deliberately in the
+  // committed .claude/dev-kit.json — company-level, not a person. We NEVER derive
+  // it from git author, email, remote URL, or any individual-linked signal.
+  let trackerType, org;
   try {
     const cfg = JSON.parse(readFileSync(join(process.cwd(), '.claude', 'dev-kit.json'), 'utf8'));
     trackerType = cfg?.tracker?.type;
+    const raw = cfg?.telemetry?.org;
+    if (typeof raw === 'string' && raw.trim()) org = raw.trim().slice(0, 64);
   } catch { /* ignore */ }
 
   let kitVersion;
@@ -109,6 +115,9 @@ try {
     api_key: apiKey,
     event: 'kit_session_completed',
     distinct_id: installId,
+    // `$groups` lets PostHog aggregate by company (group analytics) when an org
+    // label is present; the flat `org` property works even without that feature.
+    $groups: org ? { company: org } : undefined,
     properties: {
       $process_person_profile: false, // anonymous: no person profile created
       schema: 1,
@@ -116,6 +125,7 @@ try {
       claude_code_version: event.version || undefined,
       os: process.platform,
       tracker_type: trackerType,
+      org, // self-declared organisation label, or undefined
       tokens_input: tok.input,
       tokens_output: tok.output,
       tokens_cache_read: tok.cacheRead,

--- a/scripts/telemetry.mjs
+++ b/scripts/telemetry.mjs
@@ -1,55 +1,69 @@
 #!/usr/bin/env node
 /*
- * Anonymous, opt-in usage telemetry for claude-dev-kit → PostHog.
+ * Anonymous, opt-in usage telemetry for claude-dev-kit.
  *
- * Ships OFF. It emits ONLY when BOTH are true:
- *   1. The user opted in (telemetry_enabled = true).
+ * Ships OFF. Sends ONLY when ALL hold:
+ *   1. The user granted consent (via the `create-dev-kit` wizard, stored in
+ *      ~/.claude/dev-kit-telemetry/config.json), and
  *   2. A kit command/agent actually ran in the session (honest attribution).
  *
- * It sends token COUNTS and coarse metadata only. It NEVER reads or sends:
- * prompts, code, diffs, file paths, repo names, ticket contents, emails, org names,
- * or the session id. It fails silent and never blocks or slows the session.
+ * The client NEVER talks to PostHog directly and ships NO API key. It sends a
+ * sanitized event to the relay, which re-enforces the contract
+ * (telemetry/contract.v1.json), strips the IP, and forwards to PostHog.
  *
- * Destination: PostHog. The PostHog project API key is a WRITE-ONLY public key,
- * safe to ship in an open-source repo — set DEFAULT_POSTHOG_KEY below before release.
- * The event is sent as anonymous ($process_person_profile: false), so no person
- * profile is created; the only identifier is a random installId.
+ * It sends token COUNTS + coarse metadata only. It NEVER reads or sends prompts,
+ * code, paths, repo names, ticket content, emails, or org-instance data. It fails
+ * silent and never blocks or slows the session.
  *
- * Opt out any time with: DEVKIT_TELEMETRY=0  (env), or set telemetry_enabled=false.
+ * Opt out any time: DEVKIT_TELEMETRY=0, or set consent to "denied" in the config.
  * See TELEMETRY.md for the full schema.
  */
-import { readFileSync, existsSync, writeFileSync } from 'node:fs';
+import { readFileSync, existsSync, writeFileSync, mkdirSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { join, dirname } from 'node:path';
 import { randomUUID } from 'node:crypto';
-
-// The Agile Monkeys' PostHog project. The project API key is write-only/public.
-// Fill these before publishing a release (or override per-user via plugin options / env).
-const DEFAULT_POSTHOG_KEY = '__THEAM_POSTHOG_PROJECT_KEY__';
-const DEFAULT_POSTHOG_HOST = 'https://eu.i.posthog.com';
 
 const done = () => process.exit(0); // fail-silent, always
 
 try {
-  // --- Kill switch + opt-in gate -------------------------------------------
   if (process.env.DEVKIT_TELEMETRY === '0') done();
 
-  const enabled = String(process.env.CLAUDE_PLUGIN_OPTION_TELEMETRY_ENABLED || '').toLowerCase();
-  const isEnabled = enabled === 'true' || enabled === '1' || enabled === 'yes';
-  if (!isEnabled) done();
+  // --- Consent (written by the create-dev-kit wizard) ----------------------
+  const cfgPath = join(homedir(), '.claude', 'dev-kit-telemetry', 'config.json');
+  let consentCfg = {};
+  try { consentCfg = JSON.parse(readFileSync(cfgPath, 'utf8')); } catch { /* absent */ }
 
-  const apiKey =
-    process.env.CLAUDE_PLUGIN_OPTION_POSTHOG_API_KEY ||
-    process.env.POSTHOG_API_KEY ||
-    DEFAULT_POSTHOG_KEY;
-  const host = (
-    process.env.CLAUDE_PLUGIN_OPTION_POSTHOG_HOST ||
-    process.env.POSTHOG_HOST ||
-    DEFAULT_POSTHOG_HOST
+  const envEnabled = String(
+    process.env.DEVKIT_TELEMETRY_ENABLED ||
+    process.env.CLAUDE_PLUGIN_OPTION_TELEMETRY_ENABLED || '').toLowerCase();
+  const granted =
+    consentCfg.consent === 'granted' ||
+    envEnabled === 'true' || envEnabled === '1' || envEnabled === 'yes';
+  if (!granted) done();
+
+  // --- Relay endpoint (no PostHog key lives in the client) -----------------
+  let defaultRelay = 'https://claude-dev-kit-telemetry.vercel.app';
+  try {
+    const root = process.env.CLAUDE_PLUGIN_ROOT || '.';
+    defaultRelay = JSON.parse(
+      readFileSync(join(root, 'telemetry', 'contract.v1.json'), 'utf8')
+    ).default_relay_url || defaultRelay;
+  } catch { /* use fallback */ }
+  const relay = (
+    process.env.DEVKIT_TELEMETRY_RELAY_URL || consentCfg.relay_url || defaultRelay
   ).replace(/\/+$/, '');
-  if (!apiKey || apiKey === '__THEAM_POSTHOG_PROJECT_KEY__') done();
 
-  // --- Read the hook event payload from stdin ------------------------------
+  // --- Stable, anonymous install id ----------------------------------------
+  let installId = consentCfg.install_id;
+  if (!installId) {
+    installId = randomUUID();
+    try { mkdirSync(dirname(cfgPath), { recursive: true }); } catch { /* ignore */ }
+    try {
+      writeFileSync(cfgPath, JSON.stringify({ ...consentCfg, consent: 'granted', install_id: installId }, null, 2));
+    } catch { /* ignore */ }
+  }
+
+  // --- Hook event payload from stdin ---------------------------------------
   const raw = readFileSync(0, 'utf8');
   const event = raw ? JSON.parse(raw) : {};
   const transcriptPath = event.transcript_path;
@@ -64,14 +78,16 @@ try {
     'e2e-generate', 'e2e-author', 'pr-review', 'pr-reviewer', 'pr-fixer',
     'fix-pr', 'create-pr', 'security-reviewer', 'figma-fetch', 'dev-kit-setup',
   ];
-  const kitRan = lines.some((l) => KIT_MARKERS.some((m) => l.includes(m)));
-  if (!kitRan) done();
+  if (!lines.some((l) => KIT_MARKERS.some((m) => l.includes(m)))) done();
 
   // --- Sum token usage. Message CONTENT is never inspected. ----------------
   const tok = { input: 0, output: 0, cacheRead: 0, cacheCreation: 0 };
+  let firstTs, lastTs;
   for (const line of lines) {
     let obj;
     try { obj = JSON.parse(line); } catch { continue; }
+    const ts = Date.parse(obj?.timestamp || '');
+    if (!Number.isNaN(ts)) { firstTs = firstTs ?? ts; lastTs = ts; }
     const u = obj?.message?.usage || obj?.usage;
     if (!u) continue;
     tok.input += u.input_tokens || 0;
@@ -81,27 +97,22 @@ try {
   }
   if (tok.input + tok.output === 0) done();
 
-  // --- Stable, anonymous install id (random — not derived from anything) ---
-  const idFile = join(homedir(), '.claude', 'dev-kit-telemetry-id');
-  let installId;
-  if (existsSync(idFile)) {
-    installId = readFileSync(idFile, 'utf8').trim();
-  } else {
-    installId = randomUUID();
-    try { writeFileSync(idFile, installId); } catch { /* ignore */ }
+  // --- Coarse duration bucket (never a raw timestamp) ----------------------
+  let durationBucket;
+  if (firstTs != null && lastTs != null && lastTs >= firstTs) {
+    const mins = (lastTs - firstTs) / 60000;
+    durationBucket =
+      mins < 1 ? 'lt_1m' : mins < 5 ? '1m_to_5m' : mins < 15 ? '5m_to_15m'
+      : mins < 60 ? '15m_to_1h' : 'gte_1h';
   }
 
-  // --- Coarse category + self-declared org label (never auto-derived) ------
-  // `tracker.type` is the adapter category (never the instance).
-  // `telemetry.org` is an ORGANISATION label the team sets deliberately in the
-  // committed .claude/dev-kit.json — company-level, not a person. We NEVER derive
-  // it from git author, email, remote URL, or any individual-linked signal.
+  // --- Self-declared org label (never auto-derived) ------------------------
   let trackerType, org;
   try {
     const cfg = JSON.parse(readFileSync(join(process.cwd(), '.claude', 'dev-kit.json'), 'utf8'));
     trackerType = cfg?.tracker?.type;
-    const raw = cfg?.telemetry?.org;
-    if (typeof raw === 'string' && raw.trim()) org = raw.trim().slice(0, 64);
+    const rawOrg = cfg?.telemetry?.org;
+    if (typeof rawOrg === 'string' && rawOrg.trim()) org = rawOrg.trim().slice(0, 64);
   } catch { /* ignore */ }
 
   let kitVersion;
@@ -110,22 +121,19 @@ try {
     kitVersion = JSON.parse(readFileSync(join(root, '.claude-plugin', 'plugin.json'), 'utf8')).version;
   } catch { /* ignore */ }
 
-  // --- PostHog capture event (anonymous) -----------------------------------
+  // --- Send the sanitized event to the relay (no API key here) -------------
   const payload = {
-    api_key: apiKey,
-    event: 'kit_session_completed',
-    distinct_id: installId,
-    // `$groups` lets PostHog aggregate by company (group analytics) when an org
-    // label is present; the flat `org` property works even without that feature.
-    $groups: org ? { company: org } : undefined,
+    schema_version: 1,
+    event_name: 'kit_session_completed',
+    install_id: installId,
+    org, // undefined unless self-declared
     properties: {
-      $process_person_profile: false, // anonymous: no person profile created
-      schema: 1,
+      schema_version: 1,
       kit_version: kitVersion,
       claude_code_version: event.version || undefined,
       os: process.platform,
       tracker_type: trackerType,
-      org, // self-declared organisation label, or undefined
+      duration_bucket: durationBucket,
       tokens_input: tok.input,
       tokens_output: tok.output,
       tokens_cache_read: tok.cacheRead,
@@ -136,7 +144,7 @@ try {
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), 3000);
-  await fetch(`${host}/capture/`, {
+  await fetch(`${relay}/api/ingest`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload),

--- a/skills/dev-kit-setup/SKILL.md
+++ b/skills/dev-kit-setup/SKILL.md
@@ -76,7 +76,15 @@ Figma needs no configuration — file keys come from URLs, auth is the MCP OAuth
 
 ## 5. Telemetry (optional, opt-in, off by default)
 
-Do not enable or configure telemetry here, and never turn it on silently. If the user asks about it, point them to `TELEMETRY.md` and the plugin's `telemetry_enabled` / `telemetry_endpoint` options (set per developer). Absent an explicit opt-in, it stays off.
+Do not enable or configure telemetry here, and never turn it on silently. If the user asks about it, point them to `TELEMETRY.md` and the plugin's `telemetry_enabled` option (set per developer). Absent an explicit opt-in, it stays off.
+
+An organisation that wants its usage attributed to it (company-level) may set a self-declared label in `.claude/dev-kit.json`:
+
+```json
+{ "telemetry": { "org": "acme-corp" } }
+```
+
+This is optional, organisation-level (not per-person), and only ever set deliberately by the team — never derive it from a git email, commit author, or remote URL. Only add it if the user explicitly asks for company attribution.
 
 ## After setup
 

--- a/telemetry/contract.v1.json
+++ b/telemetry/contract.v1.json
@@ -1,0 +1,32 @@
+{
+  "schema_version": 1,
+  "event_name": "kit_session_completed",
+  "default_relay_url": "https://claude-dev-kit-telemetry.vercel.app",
+  "duration_buckets": ["lt_1m", "1m_to_5m", "5m_to_15m", "15m_to_1h", "gte_1h"],
+  "allowed_properties": {
+    "schema_version": { "type": "integer", "const": 1 },
+    "kit_version": { "type": "version" },
+    "claude_code_version": { "type": "version", "optional": true },
+    "os": { "type": "enum", "values": ["darwin", "linux", "win32"] },
+    "tracker_type": { "type": "enum", "values": ["jira", "linear", "github", "azure"], "optional": true },
+    "org": { "type": "string", "maxLength": 64, "optional": true },
+    "duration_bucket": { "type": "enum", "values": ["lt_1m", "1m_to_5m", "5m_to_15m", "15m_to_1h", "gte_1h"], "optional": true },
+    "tokens_input": { "type": "integer", "min": 0 },
+    "tokens_output": { "type": "integer", "min": 0 },
+    "tokens_cache_read": { "type": "integer", "min": 0 },
+    "tokens_cache_creation": { "type": "integer", "min": 0 },
+    "tokens_total": { "type": "integer", "min": 0 }
+  },
+  "identity": {
+    "distinct_id": "random per-install UUID (install_id) — not derived from any personal or machine attribute",
+    "group": { "type": "company", "key": "org", "note": "present only if the organisation self-declared an org label" }
+  },
+  "never_collected": [
+    "prompts, responses, code, diffs",
+    "file paths, file names, repo names or URLs",
+    "ticket keys or contents, commit messages, branch names",
+    "emails, usernames, personal names",
+    "raw tool input/output, command arguments, stack traces",
+    "client IP (stripped at the relay, never stored)"
+  ]
+}


### PR DESCRIPTION
Follow-up to #1 (merged at v0.5.0). Adds the two commits that landed after #1 was merged: **organisation-level attribution** and the **relay + contract + setup-wizard** rework of telemetry. Bumps `v0.5.0` → `v0.6.0`.

## What changed

**Company attribution (opt-in, organisation-level)**
- Optional self-declared `telemetry.org` label in `.claude/dev-kit.json` → sent as `org` + a PostHog `company` group. GDPR-safe by construction: identifies a company (not a person), self-declared, never derived from git author/email/username/remote URL.

**Telemetry reworked onto a relay + contract (mirrors theam/limina)**
- **Contract** (`telemetry/contract.v1.json`): allowlisted properties, enums, bounds, explicit never-collected list.
- **Relay** (`packages/telemetry-relay/`, Vercel): clients ship **no PostHog key** and never call PostHog directly. The relay re-enforces the contract (drops unknown props / invalid enums), **never stores the caller IP**, and forwards an anonymous event using a key held only in its environment.
- **Hook**: consent read from `~/.claude/dev-kit-telemetry/config.json`; coarse `duration_bucket`; POST to `<relay>/api/ingest`. Still OFF by default, kit-usage gate, token counts only, no PII, fail-silent.
- `plugin.json`: dropped the PostHog userConfig (key no longer in the client); kept `telemetry_enabled` as a fallback toggle.

**Setup wizard**
- `packages/create-dev-kit` — zero-dependency `npm create @theam/dev-kit`. Picks tracker + Figma, shows the telemetry contract and captures **informed consent**, sets the org label, writes both configs, and can run the plugin install.

## Verified end to end
Wizard writes both configs → hook reads consent, sums tokens, POSTs keyless to the relay with org + duration bucket → relay sanitizes (drops disallowed props and bad enums) and forwards to PostHog. JSON/JS all validated.

## Before publishing (maintainer infra — not code)
- [ ] Deploy `packages/telemetry-relay/` (Vercel) and set `POSTHOG_API_KEY` (+ `POSTHOG_HOST`, EU).
- [ ] Point `default_relay_url` in `telemetry/contract.v1.json` at the deployment (keep the relay package copy in sync).
- [ ] Publish `@theam/create-dev-kit` to npm.
- [ ] PostHog: disable client-IP capture; relay host: don't log IPs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)