### PR TITLE
Per-stack baseline profiles (iteration zero for common stacks) — v0.7.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fullstack-dev-kit",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Issue-to-PR workflow kit for any tech stack. Fetch a user story from your tracker (Jira, Linear, GitHub Issues, Azure DevOps) and any linked Figma designs, implement with plan approval, enforce >95% coverage and a security pass, generate e2e tests, open the PR, fix review findings, and move the ticket to review.",
   "license": "Apache-2.0",
   "homepage": "https://github.com/theam/claude-dev-kit",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,7 @@ Check the troubleshooting table in the [README](README.md#troubleshooting) first
 | `skills/` | Skill playbooks — one folder per skill, each with a `SKILL.md` |
 | `commands/` | Slash commands (`/work-story`, `/launch-story`) |
 | `instructions/` | Always-on, language-agnostic rules (secure coding, testing standards) |
+| `instructions/stacks/` | Per-stack baseline profiles (commands, coverage format, e2e, conventions) |
 | `hooks/` + `scripts/` | Opt-in telemetry hook and its script (see [TELEMETRY.md](TELEMETRY.md)) |
 | `.claude-plugin/` | Plugin + marketplace manifests |
 | `.mcp.json` | Declared MCP servers (trackers, design tools) |
@@ -40,6 +41,14 @@ Check the troubleshooting table in the [README](README.md#troubleshooting) first
 2. Add a detection branch and a config shape to `skills/dev-kit-setup/SKILL.md`.
 3. If it uses an HTTP MCP, declare it in `.mcp.json`. If it uses a CLI (like `gh`), note the auth step instead.
 4. Update the reference-shape table in `issue-fetch` and the `README.md`.
+
+## Adding or improving a stack profile
+
+The kit ships baseline "iteration zero" profiles for common stacks in [`instructions/stacks/`](instructions/stacks/) (node, python, dotnet, java, go, ruby, php, rust). **The most useful contribution is a corrected or new profile from someone who works in that stack daily.**
+
+1. Add or edit `instructions/stacks/<id>.md` following the format in [`instructions/stacks/README.md`](instructions/stacks/README.md): detection signals, commands (incl. test-with-coverage → report path + format), e2e framework, conventions and prerequisites.
+2. Add the detection signal to the table in `skills/dev-kit-setup/SKILL.md` if the stack is new.
+3. That's it — skills pick the profile up automatically via `stacks` in `.claude/dev-kit.json`. No code to touch (the skills are prompts).
 
 ## Testing your changes locally
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ Interactive setup — tracker, Figma, telemetry consent, org — then it install
 
 ## Stack-agnostic by design
 
-The kit carries **no assumptions about language, framework, or test runner**. It reads everything stack-specific — build/test/lint/coverage commands, architecture conventions, and any implementer subagents — from the **consuming repo's `CLAUDE.md` and `.claude/`**, and detects conventions from the project when they aren't declared. Use it with .NET, Node, Python, Go, Rust, Java, or anything else.
+The kit carries **no assumptions about language, framework, or test runner**. It reads everything stack-specific — build/test/lint/coverage commands, architecture conventions, and any implementer subagents — from the **consuming repo's `CLAUDE.md` and `.claude/`**, and detects conventions from the project when they aren't declared.
+
+It ships **baseline "iteration zero" profiles** for common stacks in [`instructions/stacks/`](instructions/stacks/) — **node, python, dotnet, java, go, ruby, php, rust** — giving each one usable coverage/e2e/lint commands out of the box. Your `CLAUDE.md` always overrides them, and adding a stack is one markdown file (see [CONTRIBUTING](CONTRIBUTING.md#adding-or-improving-a-stack-profile)). These profiles are early and community-refined — treat an unlisted or unverified stack as "should work, help us confirm" rather than guaranteed.
 
 It integrates with your tools through **adapters**, not hardcoded dependencies:
 

--- a/agents/coding-agent.md
+++ b/agents/coding-agent.md
@@ -27,6 +27,7 @@ The kit's always-on rules live in `instructions/secure-coding.md` and `instructi
 - Run `issue-fetch` for the ticket. Display the summary.
 - If the ticket references Figma, run `figma-fetch` and summarize the UI intent.
 - Read the consuming repo's `CLAUDE.md` files (root and any per-area files) for project-specific rules and commands.
+- Load the baseline profile for the repo's stack(s): the `stacks` in `.claude/dev-kit.json` map to `instructions/stacks/<id>.md`. The repo's `CLAUDE.md` always wins; the profile fills gaps (build/test/coverage/e2e commands, conventions). If there is no matching profile and no `CLAUDE.md`, detect conventions from the project and say so — don't assume.
 
 ### 2. Plan — WAIT FOR APPROVAL
 

--- a/instructions/stacks/README.md
+++ b/instructions/stacks/README.md
@@ -1,0 +1,57 @@
+# Stack profiles
+
+Each file here is a **baseline profile** for one tech stack — the commands and
+conventions the kit falls back to when the consuming repo doesn't spell them out.
+
+They exist so the kit has a usable **"iteration zero"** for the common stacks out
+of the box. They are intentionally generic: teams refine them for their stack via
+PR, and adding a new stack is just a new markdown file.
+
+## Precedence (most specific wins)
+
+1. The consuming repo's `CLAUDE.md` / `.claude/dev-kit.json` — always wins.
+2. The matching stack profile in this folder — the baseline used when the repo is silent.
+3. The language-agnostic rules in `../secure-coding.md` and `../testing-standards.md`.
+
+A profile never overrides what the consuming repo declares; it only fills gaps.
+
+## How it's selected
+
+`dev-kit-setup` detects the stack(s) from the project's files and records them in
+`.claude/dev-kit.json` as `"stacks": ["php"]` (or several for a monorepo). Skills
+that need stack-specific commands (`coverage-check`, `e2e-generate`) and the
+`coding-agent` load the matching profile(s) here.
+
+## Profile format
+
+Keep each profile short and factual, following this shape:
+
+```markdown
+# <Stack> — stack profile
+
+## Detect
+Files that signal this stack.
+
+## Commands
+Install / build / lint / unit test / **test with coverage** (command → report path + format).
+
+## Coverage
+Report format and where per-file metrics live, so `coverage-check` can parse it.
+
+## E2E
+Framework(s) commonly used and the run command.
+
+## Conventions & gotchas
+Layout, test naming, mocking style, prerequisites (e.g. a coverage driver), and pitfalls.
+```
+
+## Contributing a stack (or improving one)
+
+Add or edit one file here — nothing else is required for the kit to pick it up.
+Prefer the mainstream toolchain for the stack, note prerequisites (e.g. PHP needs
+Xdebug/PCOV for coverage), and keep it to what the kit actually needs: how to run
+tests, get coverage, run e2e, and the conventions a reviewer would expect. See the
+main [CONTRIBUTING.md](../../CONTRIBUTING.md).
+
+Current profiles: `dotnet`, `go`, `java`, `node`, `php`, `python`, `ruby`, `rust`.
+Everything here is iteration zero — corrections from people who work in the stack daily are the most valuable contribution.

--- a/instructions/stacks/dotnet.md
+++ b/instructions/stacks/dotnet.md
@@ -1,5 +1,7 @@
 # .NET / C# — stack profile
 
+> **Iteration zero.** A starting baseline, not yet verified end to end. If you work in this stack, please improve it — corrections and additions are very welcome via PR (see [README](./README.md)).
+
 Baseline for .NET projects. The repo's `CLAUDE.md`, `*.sln`, and `*.csproj` settings win over this.
 
 ## Detect

--- a/instructions/stacks/dotnet.md
+++ b/instructions/stacks/dotnet.md
@@ -1,0 +1,25 @@
+# .NET / C# — stack profile
+
+Baseline for .NET projects. The repo's `CLAUDE.md`, `*.sln`, and `*.csproj` settings win over this.
+
+## Detect
+`*.sln` or `*.csproj`. Test projects usually reference `xunit`, `nunit`, or `MSTest` plus `coverlet`.
+
+## Commands
+- Restore/build: `dotnet restore` && `dotnet build`.
+- Lint/format: `dotnet format --verify-no-changes` (plus any analyzers configured).
+- Unit tests: `dotnet test`.
+- Tests with coverage: `dotnet test --collect:"XPlat Code Coverage" --results-directory ./TestResults`
+  - Or coverlet MSBuild: `dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura`.
+
+## Coverage
+- Report: `TestResults/**/coverage.cobertura.xml` (Cobertura). Parse per-file line/branch metrics from it.
+- If the repo defines coverlet settings or a coverage command in `CLAUDE.md`/`.csproj`, prefer those.
+
+## E2E
+- Playwright for .NET or Selenium.WebDriver (commonly a separate test project). Reuse existing page models and driver setup.
+
+## Conventions & gotchas
+- Test naming: `Method_Scenario_ExpectedResult`; one behaviour per test.
+- Responses return DTOs, not entities; validate at the request boundary.
+- Multiple test projects: aggregate the Cobertura files for per-file coverage across the touched files.

--- a/instructions/stacks/go.md
+++ b/instructions/stacks/go.md
@@ -1,0 +1,25 @@
+# Go — stack profile
+
+Baseline for Go projects. The repo's `CLAUDE.md` and `Makefile` targets win over this.
+
+## Detect
+`go.mod`. Tests are `*_test.go` files using the standard `testing` package.
+
+## Commands
+- Build: `go build ./...`.
+- Lint/vet: `go vet ./...` and `golangci-lint run` if configured; format: `gofmt -l .`.
+- Unit tests: `go test ./...`.
+- Tests with coverage: `go test ./... -coverprofile=cover.out -covermode=atomic`
+  - Per-package/func summary: `go tool cover -func=cover.out`.
+
+## Coverage
+- Report: `cover.out` (Go coverprofile). `go tool cover -func` gives per-function and total %; parse it for per-file coverage of touched files.
+- Go coverage is line-based; branch/function metrics aren't native — report line coverage and say so rather than inventing a branch number.
+
+## E2E
+- API/integration via `net/http/httptest` and table-driven tests. Web UI (if any) via Playwright/Selenium against the built binary.
+
+## Conventions & gotchas
+- Table-driven tests, `t.Run` subtests; keep tests in the same package or `_test` package.
+- No unseeded randomness or real clocks — inject them.
+- `-covermode=atomic` when tests run in parallel.

--- a/instructions/stacks/go.md
+++ b/instructions/stacks/go.md
@@ -1,5 +1,7 @@
 # Go — stack profile
 
+> **Iteration zero.** A starting baseline, not yet verified end to end. If you work in this stack, please improve it — corrections and additions are very welcome via PR (see [README](./README.md)).
+
 Baseline for Go projects. The repo's `CLAUDE.md` and `Makefile` targets win over this.
 
 ## Detect

--- a/instructions/stacks/java.md
+++ b/instructions/stacks/java.md
@@ -1,0 +1,26 @@
+# Java (JVM) — stack profile
+
+Baseline for Java/Kotlin JVM projects. The repo's `CLAUDE.md`, `pom.xml`, or Gradle build win over this.
+
+## Detect
+`pom.xml` (Maven) or `build.gradle` / `build.gradle.kts` (Gradle). Tests: JUnit 5 / JUnit 4 / TestNG.
+
+## Commands
+- Build: `mvn -q verify -DskipTests` or `./gradlew build -x test`.
+- Lint/format: Checkstyle / Spotless (`mvn spotless:check` or `./gradlew spotlessCheck`) if configured.
+- Unit tests: `mvn test` or `./gradlew test`.
+- Tests with coverage (JaCoCo):
+  - Maven: `mvn test` with the JaCoCo plugin → `target/site/jacoco/jacoco.xml`
+  - Gradle: `./gradlew test jacocoTestReport` → `build/reports/jacoco/test/jacocoTestReport.xml`
+
+## Coverage
+- Report: JaCoCo XML (paths above). Parse per-class/line/branch counters. Enable the XML reporter if only HTML is produced.
+- Kotlin projects may use Kover (`./gradlew koverXmlReport` → `build/reports/kover/report.xml`).
+
+## E2E
+- Selenium.WebDriver or Playwright for Java; Rest-Assured for API flows.
+
+## Conventions & gotchas
+- Tests under `src/test/java`, mirror the package of the class under test.
+- Prefer constructor injection + real in-memory collaborators over deep mocking.
+- Gradle vs Maven: detect from the build file present and use its wrapper (`./gradlew`, `./mvnw`) when available.

--- a/instructions/stacks/java.md
+++ b/instructions/stacks/java.md
@@ -1,5 +1,7 @@
 # Java (JVM) — stack profile
 
+> **Iteration zero.** A starting baseline, not yet verified end to end. If you work in this stack, please improve it — corrections and additions are very welcome via PR (see [README](./README.md)).
+
 Baseline for Java/Kotlin JVM projects. The repo's `CLAUDE.md`, `pom.xml`, or Gradle build win over this.
 
 ## Detect

--- a/instructions/stacks/node.md
+++ b/instructions/stacks/node.md
@@ -1,5 +1,7 @@
 # Node / JavaScript / TypeScript — stack profile
 
+> **Iteration zero.** A starting baseline, not yet verified end to end. If you work in this stack, please improve it — corrections and additions are very welcome via PR (see [README](./README.md)).
+
 Baseline for Node projects. The repo's `CLAUDE.md` and `package.json` scripts win over this.
 
 ## Detect

--- a/instructions/stacks/node.md
+++ b/instructions/stacks/node.md
@@ -1,0 +1,29 @@
+# Node / JavaScript / TypeScript — stack profile
+
+Baseline for Node projects. The repo's `CLAUDE.md` and `package.json` scripts win over this.
+
+## Detect
+`package.json`. TypeScript if `tsconfig.json` is present. Test runner from devDependencies (`jest`, `vitest`, `mocha`) or the `test` script.
+
+## Commands
+- Install: `npm ci` (or `pnpm i` / `yarn` — match the lockfile present).
+- Build: `npm run build` if defined.
+- Lint: `npm run lint` (usually ESLint); type-check: `npx tsc --noEmit`.
+- Unit tests: `npm test`.
+- Tests with coverage:
+  - Jest: `npx jest --coverage`
+  - Vitest: `npx vitest run --coverage`
+  - Prefer a repo script if present: `npm run test:coverage`.
+
+## Coverage
+- Report: `coverage/lcov.info` (lcov) and/or `coverage/coverage-summary.json` (json-summary). Enable json-summary/lcov reporters if missing.
+- Per-file line/branch/function metrics come straight from `coverage-summary.json` or the `lcov.info` records.
+
+## E2E
+- Playwright (`npx playwright test`) or Cypress (`npx cypress run`). Reuse the existing config and page objects; never introduce a second framework.
+
+## Conventions & gotchas
+- Never use `any` in tests; no `require()` in TS test files.
+- Mock at boundaries (HTTP, db, clock), not between same-layer collaborators.
+- Match the package manager to the lockfile (`package-lock.json` → npm, `pnpm-lock.yaml` → pnpm, `yarn.lock` → yarn).
+- Monorepos: run tests per workspace/package and merge per-file coverage.

--- a/instructions/stacks/php.md
+++ b/instructions/stacks/php.md
@@ -1,0 +1,25 @@
+# PHP — stack profile
+
+Baseline for PHP projects (Laravel, Symfony, or plain). The repo's `CLAUDE.md` and `composer.json` scripts win over this.
+
+## Detect
+`composer.json`. Tests: PHPUnit (`phpunit.xml`/`phpunit.xml.dist`) or Pest. Framework: Laravel (`artisan`) / Symfony (`bin/console`).
+
+## Commands
+- Install: `composer install`.
+- Lint/static analysis: `vendor/bin/php-cs-fixer fix --dry-run` / `vendor/bin/phpcs`; `vendor/bin/phpstan analyse` or `vendor/bin/psalm` if configured.
+- Unit tests: `vendor/bin/phpunit` (or `vendor/bin/pest`, or `php artisan test` on Laravel).
+- Tests with coverage: `vendor/bin/phpunit --coverage-clover coverage.xml`
+  - Pest: `vendor/bin/pest --coverage --coverage-clover coverage.xml`.
+
+## Coverage
+- Report: `coverage.xml` (**Clover** format). Parse per-file line/branch metrics from the `<file>` / `<metrics>` nodes.
+- **Prerequisite:** coverage needs a driver — **Xdebug** (`XDEBUG_MODE=coverage`) or **PCOV** installed. Without it PHPUnit reports no coverage; detect this and say so rather than reporting 0%.
+
+## E2E
+- Laravel Dusk or Codeception for full-stack; Playwright/Cypress for a decoupled frontend; API flows via PHPUnit feature tests against the app.
+
+## Conventions & gotchas
+- PSR-4 layout; tests under `tests/` (`tests/Unit`, `tests/Feature`).
+- Laravel: use `RefreshDatabase`/transactions for isolation; factories over shared fixtures.
+- Confirm the coverage driver is present before trusting (or failing) the 95% gate.

--- a/instructions/stacks/php.md
+++ b/instructions/stacks/php.md
@@ -1,5 +1,7 @@
 # PHP — stack profile
 
+> **Iteration zero.** A starting baseline, not yet verified end to end. If you work in this stack, please improve it — corrections and additions are very welcome via PR (see [README](./README.md)).
+
 Baseline for PHP projects (Laravel, Symfony, or plain). The repo's `CLAUDE.md` and `composer.json` scripts win over this.
 
 ## Detect

--- a/instructions/stacks/python.md
+++ b/instructions/stacks/python.md
@@ -1,5 +1,7 @@
 # Python — stack profile
 
+> **Iteration zero.** A starting baseline, not yet verified end to end. If you work in this stack, please improve it — corrections and additions are very welcome via PR (see [README](./README.md)).
+
 Baseline for Python projects. The repo's `CLAUDE.md`, `pyproject.toml`, or `tox.ini` win over this.
 
 ## Detect

--- a/instructions/stacks/python.md
+++ b/instructions/stacks/python.md
@@ -1,0 +1,26 @@
+# Python — stack profile
+
+Baseline for Python projects. The repo's `CLAUDE.md`, `pyproject.toml`, or `tox.ini` win over this.
+
+## Detect
+`pyproject.toml`, `setup.py`, `setup.cfg`, or `requirements*.txt`. Test framework: `pytest` (default) or `unittest`.
+
+## Commands
+- Install: `pip install -e .[dev]` or `pip install -r requirements-dev.txt`; use `poetry install` / `uv sync` if that's the project's tool.
+- Lint/format: `ruff check` (or `flake8`) and `ruff format` / `black`; type-check: `mypy` if configured.
+- Unit tests: `pytest`.
+- Tests with coverage: `pytest --cov --cov-report=xml --cov-report=term-missing`
+  - `--cov=<package>` to scope to the source package.
+
+## Coverage
+- Report: `coverage.xml` (Cobertura format) — the default for `coverage-check` to parse. `.coverage` (SQLite) or `coverage json` are alternatives.
+- `--cov-report=term-missing` lists uncovered lines inline, useful for closing gaps.
+
+## E2E
+- Web UI: Playwright for Python (`pytest` + `playwright`) or Selenium. API: `pytest` against a running app or `TestClient` (FastAPI) / Django test client.
+
+## Conventions & gotchas
+- Tests in `tests/`, files `test_*.py`, one behaviour per test.
+- Use fixtures; avoid module-level mutable state shared across tests.
+- Respect the project's env manager (venv / poetry / uv / conda) — don't install globally.
+- Coverage needs the source importable; run from the repo root with the right `PYTHONPATH`/install.

--- a/instructions/stacks/ruby.md
+++ b/instructions/stacks/ruby.md
@@ -1,0 +1,24 @@
+# Ruby — stack profile
+
+Baseline for Ruby / Rails projects. The repo's `CLAUDE.md` and `Gemfile` win over this.
+
+## Detect
+`Gemfile` or `*.gemspec`. Tests: RSpec (`spec/`) or Minitest (`test/`). Rails if `config/application.rb` exists.
+
+## Commands
+- Install: `bundle install`.
+- Lint: `bundle exec rubocop`.
+- Unit tests: `bundle exec rspec` or `bin/rails test`.
+- Tests with coverage: run the suite with **SimpleCov** enabled (add `require 'simplecov'; SimpleCov.start` at the top of `spec/spec_helper.rb` or `test/test_helper.rb` if missing).
+
+## Coverage
+- Report: `coverage/.resultset.json` and `coverage/coverage.json` (SimpleCov). Parse per-file line coverage from there.
+- For a machine-friendly format, add `simplecov-lcov` → `coverage/lcov.info`. SimpleCov is line-based (no native branch coverage unless `enable_coverage :branch` is set).
+
+## E2E
+- Rails system tests (Capybara + Selenium/`cuprite`), or Playwright/Cypress for a decoupled frontend.
+
+## Conventions & gotchas
+- RSpec: `describe`/`context`/`it` with behaviour-focused names; use factories (FactoryBot), not fixtures with shared mutable state.
+- Enable SimpleCov before the app loads or coverage under-reports.
+- Rails: use `ActiveRecord` transactions / `database_cleaner` for isolation.

--- a/instructions/stacks/ruby.md
+++ b/instructions/stacks/ruby.md
@@ -1,5 +1,7 @@
 # Ruby — stack profile
 
+> **Iteration zero.** A starting baseline, not yet verified end to end. If you work in this stack, please improve it — corrections and additions are very welcome via PR (see [README](./README.md)).
+
 Baseline for Ruby / Rails projects. The repo's `CLAUDE.md` and `Gemfile` win over this.
 
 ## Detect

--- a/instructions/stacks/rust.md
+++ b/instructions/stacks/rust.md
@@ -1,0 +1,25 @@
+# Rust — stack profile
+
+Baseline for Rust projects. The repo's `CLAUDE.md` and `Cargo.toml` win over this.
+
+## Detect
+`Cargo.toml`. Tests are `#[test]` functions (unit, in-module) and integration tests under `tests/`.
+
+## Commands
+- Build: `cargo build`.
+- Lint/format: `cargo clippy -- -D warnings` and `cargo fmt --check`.
+- Unit tests: `cargo test`.
+- Tests with coverage (prefer `cargo-llvm-cov`): `cargo llvm-cov --lcov --output-path lcov.info`
+  - Alternative: `cargo tarpaulin --out Xml` → `cobertura.xml`.
+
+## Coverage
+- Report: `lcov.info` (lcov) from llvm-cov, or `cobertura.xml` from tarpaulin. Parse per-file line/region coverage.
+- `cargo llvm-cov --summary-only` prints totals; the tool requires the `llvm-tools-preview` component.
+
+## E2E
+- Less common; for web services, integration tests under `tests/` hitting a spawned server, or Playwright/Selenium against the built binary for any UI.
+
+## Conventions & gotchas
+- Unit tests live in a `#[cfg(test)] mod tests` block next to the code; integration tests in `tests/`.
+- Deterministic tests: inject clocks/RNG, no reliance on wall-clock or thread ordering.
+- Workspaces: run coverage per crate and aggregate for the touched files.

--- a/instructions/stacks/rust.md
+++ b/instructions/stacks/rust.md
@@ -1,5 +1,7 @@
 # Rust — stack profile
 
+> **Iteration zero.** A starting baseline, not yet verified end to end. If you work in this stack, please improve it — corrections and additions are very welcome via PR (see [README](./README.md)).
+
 Baseline for Rust projects. The repo's `CLAUDE.md` and `Cargo.toml` win over this.
 
 ## Detect

--- a/skills/coverage-check/SKILL.md
+++ b/skills/coverage-check/SKILL.md
@@ -17,7 +17,8 @@ In order of preference:
 
 1. **Declared in config** — read `.claude/dev-kit.json` (`test.coverageCommands`) and the consuming repo's `CLAUDE.md`. If a command is declared, use it verbatim.
 2. **Declared by the repo's tooling** — a `test:coverage` script in `package.json`, a `Makefile`/`Taskfile` target, a `coverage` task in the build file.
-3. **Detected from the stack** — infer from the project files present, e.g.:
+3. **From the stack profile** — if `.claude/dev-kit.json` has `stacks` (or you detect one), read `instructions/stacks/<id>.md` for the stack's coverage command, report path, and format, plus any prerequisite (e.g. PHP needs Xdebug/PCOV; without it, report that rather than 0%).
+4. **Detected from the stack** — infer from the project files present, e.g.:
 
    | Stack signal | Typical coverage command | Report produced |
    |---|---|---|

--- a/skills/dev-kit-setup/SKILL.md
+++ b/skills/dev-kit-setup/SKILL.md
@@ -41,7 +41,24 @@ Then run the matching discovery below. For any MCP/CLI that is not authenticated
 ### Azure DevOps
 - **Org and project**: read from the configured Azure DevOps connection or ask once. Store `org` and `project`.
 
-## 3. Persist
+## 3. Detect the stack(s)
+
+Identify the tech stack from the project's files so the kit can load the right baseline commands. Match against the profiles in `instructions/stacks/` (each profile lists its detection signals), e.g.:
+
+| Signal | Stack id |
+|---|---|
+| `package.json` | `node` |
+| `pyproject.toml` / `requirements*.txt` | `python` |
+| `*.csproj` / `*.sln` | `dotnet` |
+| `pom.xml` / `build.gradle` | `java` |
+| `go.mod` | `go` |
+| `Gemfile` | `ruby` |
+| `composer.json` | `php` |
+| `Cargo.toml` | `rust` |
+
+A monorepo may match several — record all of them. If nothing matches a shipped profile, record the closest label anyway and tell the user there is no stack profile yet (the kit still works from the repo's `CLAUDE.md` and generic rules — and contributing `instructions/stacks/<id>.md` is one small PR).
+
+## 4. Persist
 
 Write `.claude/dev-kit.json` at the consuming repo root. Only the active tracker's block is required:
 
@@ -59,22 +76,25 @@ Write `.claude/dev-kit.json` at the consuming repo root. Only the active tracker
     },
     "reviewState": null
   },
+  "stacks": ["node"],
   "test": {
     "coverageCommands": []
   }
 }
 ```
 
-Shape of `tracker` per type: **jira** → `site`, `cloudId`, `projectKey`, `fields`; **linear** → `teamKey`, optional `workspace`; **github** → `repo` (`owner/name`, optional if same as origin); **azure** → `org`, `project`. `reviewState` is filled the first time `issue-update` transitions an item, then reused. `test.coverageCommands` is optional — `coverage-check` fills it in when it detects the repo's coverage command.
+Shape of `tracker` per type: **jira** → `site`, `cloudId`, `projectKey`, `fields`; **linear** → `teamKey`, optional `workspace`; **github** → `repo` (`owner/name`, optional if same as origin); **azure** → `org`, `project`. `stacks` is the detected stack id(s) — skills load `instructions/stacks/<id>.md` as their baseline. `reviewState` is filled the first time `issue-update` transitions an item, then reused. `test.coverageCommands` is optional — `coverage-check` fills it in when it detects the repo's coverage command.
+
+**If the repo has no `CLAUDE.md`:** say so, proceed using the stack profile(s) + detected commands as the baseline, and suggest the user run `/init` (or let the kit propose a minimal `CLAUDE.md`) so future runs are grounded in the repo's own conventions. Never silently assume conventions the repo hasn't stated.
 
 - This file contains **no secrets** (auth lives in each developer's MCP OAuth grant or CLI login) — it is safe and intended to be committed, so one setup serves the whole team.
 - Tell the user the file was created and suggest committing it.
 
-## 4. Design tool (optional)
+## 5. Design tool (optional)
 
 Figma needs no configuration — file keys come from URLs, auth is the MCP OAuth. Verify authentication lazily, only when a Figma URL first appears.
 
-## 5. Telemetry (optional, opt-in, off by default)
+## 6. Telemetry (optional, opt-in, off by default)
 
 Do not enable or configure telemetry here, and never turn it on silently. If the user asks about it, point them to `TELEMETRY.md` and the plugin's `telemetry_enabled` option (set per developer). Absent an explicit opt-in, it stays off.
 

--- a/skills/e2e-generate/SKILL.md
+++ b/skills/e2e-generate/SKILL.md
@@ -10,7 +10,7 @@ For every user story that changes user-facing behavior, an existing e2e test mus
 ## Process
 
 1. **Identify the affected flow(s)** from the story's acceptance criteria and the diff: which pages, routes, forms, and roles are involved.
-2. **Discover the project's e2e framework and conventions first** — before writing anything. Look for the config and test tree of whatever the repo uses (e.g. `playwright.config.*` + `e2e/`, `cypress.config.*` + `cypress/`, a Selenium/WebDriver test project, `*.feature` files for Cucumber, etc.) and reuse its existing page objects, fixtures, helpers, and app/API seeding or stubbing. Follow them exactly; do not introduce a new pattern or framework when one exists. If the repo has no e2e setup at all, say so and propose one that fits the stack instead of scaffolding silently.
+2. **Discover the project's e2e framework and conventions first** — before writing anything. If `.claude/dev-kit.json` names a stack, `instructions/stacks/<id>.md` lists the frameworks common for it as a starting hint. Then look for the config and test tree of whatever the repo actually uses (e.g. `playwright.config.*` + `e2e/`, `cypress.config.*` + `cypress/`, a Selenium/WebDriver test project, `*.feature` files for Cucumber, etc.) and reuse its existing page objects, fixtures, helpers, and app/API seeding or stubbing. Follow them exactly; do not introduce a new pattern or framework when one exists. If the repo has no e2e setup at all, say so and propose one that fits the stack instead of scaffolding silently.
 3. **Prefer updating an existing test** for the flow over creating a parallel one.
 4. **Write the scenarios.** Every generated suite must cover realistic edge cases, not just the happy path:
    - Empty states


### PR DESCRIPTION
Adds baseline **stack profiles** so the kit ships usable defaults for the common stacks and the community can extend it with one markdown file per stack. Directly addresses "does it work on PHP / other stacks?" and "what if there's no CLAUDE.md?".

## What changed

**`instructions/stacks/` — profiles for the most-used stacks**
- `node`, `python`, `dotnet`, `java`, `go`, `ruby`, `php`, `rust`.
- Each: detection signals, build/test/lint commands, the **test-with-coverage** command + report path & format, e2e frameworks, and conventions/prerequisites (e.g. PHP coverage needs Xdebug/PCOV; Go has no native branch coverage).
- A `README.md` documents the format, precedence, and how to contribute.

**Wiring (no code — skills are prompts)**
- `dev-kit-setup`: detects the stack(s), persists `stacks` in `.claude/dev-kit.json`, points skills at the profile.
- `coverage-check` / `e2e-generate` / `coding-agent`: consult the matching profile. **Precedence: repo `CLAUDE.md` > stack profile > generic rules** — the profile only fills gaps.

**No-CLAUDE.md handling**
- `dev-kit-setup` now handles a repo with no `CLAUDE.md`: use the stack profile as baseline, suggest `/init` (or propose a minimal `CLAUDE.md`), and never assume conventions silently.

**Docs**
- CONTRIBUTING: "adding or improving a stack profile" — one file, no code.
- README: lists shipped profiles with an honest "iteration zero — unlisted/unverified stacks are *should work, help us confirm*".

## Why this shape
The skills are prompts, so adding a stack is **just a markdown file** — the lowest possible barrier for the PHP (and other) teams to contribute and validate their own stack.

## Still true (not solved here)
- These profiles are **unvalidated end to end** — they're a starting baseline, not a guarantee. Real story→PR runs per stack are the next step.
- PR host is still GitHub-only; the 95% coverage + e2e gates remain opinionated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)