### PR TITLE
Pluggable PR host: Bitbucket + GitLab (v0.8.0) — recover into main

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fullstack-dev-kit",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Issue-to-PR workflow kit for any tech stack. Fetch a user story from your tracker (Jira, Linear, GitHub Issues, Azure DevOps) and any linked Figma designs, implement with plan approval, enforce >95% coverage and a security pass, generate e2e tests, open the PR, fix review findings, and move the ticket to review.",
   "license": "Apache-2.0",
   "homepage": "https://github.com/theam/claude-dev-kit",

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ It integrates with your tools through **adapters**, not hardcoded dependencies:
 | Concern | Supported | How it's chosen |
 |---|---|---|
 | Issue tracker | Jira, Linear, GitHub Issues, Azure DevOps | Detected/asked once by `dev-kit-setup`, stored in `.claude/dev-kit.json` |
-| PR host | GitHub (`gh` CLI) | Default; other hosts can be added as adapters |
+| PR host | GitHub (`gh`), Bitbucket (REST), GitLab (`glab`) | Detected from the `origin` remote, stored as `prHost` |
 | Design (optional) | Figma | Activated when a ticket links a Figma URL |
 
 ## Installing in Claude Code

--- a/packages/create-dev-kit/index.mjs
+++ b/packages/create-dev-kit/index.mjs
@@ -60,12 +60,28 @@ async function main() {
   };
   if (TRACKER_HINT[tracker]) console.log(dim('   → ' + TRACKER_HINT[tracker]));
 
-  // 2. Figma
-  console.log(`\n${b('2. Design')}`);
+  // 2. Pull request host
+  console.log(`\n${b('2. Pull request host')}`);
+  const hosts = { 1: 'github', 2: 'bitbucket', 3: 'gitlab', 4: null };
+  console.log('   1) GitHub');
+  console.log('   2) Bitbucket');
+  console.log('   3) GitLab');
+  console.log('   4) Other / none');
+  const hChoice = await ask('   Where do pull requests live?', '1');
+  const prHost = hosts[hChoice] ?? 'github';
+  const HOST_HINT = {
+    github: 'Authenticate the GitHub CLI: gh auth login',
+    bitbucket: 'Bitbucket: create an app password / access token and export it (e.g. BITBUCKET_TOKEN).\n     The kit pushes with git and opens the PR via the Bitbucket REST API.',
+    gitlab: 'Authenticate the GitLab CLI: glab auth login',
+  };
+  if (HOST_HINT[prHost]) console.log(dim('   → ' + HOST_HINT[prHost]));
+
+  // 3. Figma
+  console.log(`\n${b('3. Design')}`);
   const figma = await yn('   Will you link Figma designs in tickets?', false);
 
-  // 3. Telemetry — informed consent
-  console.log(`\n${b('3. Anonymous usage telemetry')} ${dim('(optional)')}`);
+  // 4. Telemetry — informed consent
+  console.log(`\n${b('4. Anonymous usage telemetry')} ${dim('(optional)')}`);
   console.log(dim(
     '   If you opt in, at the end of sessions where the kit runs it sends, to\n' +
     '   The Agile Monkeys via a relay:\n' +
@@ -78,10 +94,10 @@ async function main() {
   ));
   const consent = await yn('   Share anonymous usage telemetry?', false);
 
-  // 4. Organisation label (only meaningful if telemetry is on)
+  // 5. Organisation label (only meaningful if telemetry is on)
   let org = '';
   if (consent) {
-    console.log(`\n${b('4. Organisation')} ${dim('(optional — attributes your usage to your company, not a person)')}`);
+    console.log(`\n${b('5. Organisation')} ${dim('(optional — attributes your usage to your company, not a person)')}`);
     org = await ask('   Organisation label to tag your usage (leave empty to stay unattributed):', '');
   }
 
@@ -89,6 +105,7 @@ async function main() {
   const repoCfgPath = join(process.cwd(), '.claude', 'dev-kit.json');
   const repoPatch = { figma };
   if (tracker) repoPatch.tracker = { type: tracker };
+  if (prHost) repoPatch.prHost = prHost;
   if (org.trim()) repoPatch.telemetry = { org: org.trim().slice(0, 64) };
   mergeJson(repoCfgPath, repoPatch);
 

--- a/skills/create-pr/SKILL.md
+++ b/skills/create-pr/SKILL.md
@@ -25,7 +25,14 @@ If any gate fails, stop and report what is missing instead of opening the PR.
 
 ## Pull request
 
-Open with `gh pr create` (or the repo's tooling). The body must include:
+Open the PR on the configured host (`prHost` in `.claude/dev-kit.json`; default `github`). Branch/commit/push are the same everywhere (plain git); only the "open the PR" call differs:
+
+- **github** — `gh pr create` (`gh` authenticated).
+- **bitbucket** — push the branch, then create the PR via the REST API: `POST https://api.bitbucket.org/2.0/repositories/{workspace}/{repo_slug}/pullrequests` with `{title, source:{branch:{name}}, destination:{branch:{name}}}`, authenticated with a Bitbucket app password / access token from the environment (e.g. `BITBUCKET_TOKEN`). The `acli` CLI works too if the team uses it. Derive `{workspace}/{repo_slug}` from the `origin` remote.
+- **gitlab** — `glab mr create` (`glab` authenticated).
+- **other/none** — print the branch and the ready-to-paste PR title/body and let the user open it.
+
+The body must include (adapt field names to the host — GitHub/GitLab render Markdown; Bitbucket PR descriptions accept Markdown too):
 
 ```
 ![AI-generated](https://img.shields.io/badge/%F0%9F%A4%96_AI--generated-Claude_Code_%C2%B7_fullstack--dev--kit-8A2BE2)
@@ -61,7 +68,7 @@ Use the repo's PR template instead if one exists (`.github/PULL_REQUEST_TEMPLATE
 
 **AI traceability metadata**, best effort after creation:
 
-- Add the label `ai-generated` to the PR (`gh pr edit <url> --add-label ai-generated`). If the label does not exist and you have permission, create it once (`gh label create ai-generated --color 8A2BE2 --description "Opened by an AI agent"`); if no permission, skip silently — the badge and footer already carry the signal.
+- Add an `ai-generated` label/tag to the PR when the host supports it — GitHub: `gh pr edit <url> --add-label ai-generated` (create it once with `gh label create ai-generated --color 8A2BE2` if missing); Bitbucket/GitLab: skip or use the host's equivalent. If not possible, skip silently — the badge and footer already carry the signal.
 
 ## After creation
 

--- a/skills/dev-kit-setup/SKILL.md
+++ b/skills/dev-kit-setup/SKILL.md
@@ -77,13 +77,14 @@ Write `.claude/dev-kit.json` at the consuming repo root. Only the active tracker
     "reviewState": null
   },
   "stacks": ["node"],
+  "prHost": "github",
   "test": {
     "coverageCommands": []
   }
 }
 ```
 
-Shape of `tracker` per type: **jira** → `site`, `cloudId`, `projectKey`, `fields`; **linear** → `teamKey`, optional `workspace`; **github** → `repo` (`owner/name`, optional if same as origin); **azure** → `org`, `project`. `stacks` is the detected stack id(s) — skills load `instructions/stacks/<id>.md` as their baseline. `reviewState` is filled the first time `issue-update` transitions an item, then reused. `test.coverageCommands` is optional — `coverage-check` fills it in when it detects the repo's coverage command.
+Shape of `tracker` per type: **jira** → `site`, `cloudId`, `projectKey`, `fields`; **linear** → `teamKey`, optional `workspace`; **github** → `repo` (`owner/name`, optional if same as origin); **azure** → `org`, `project`. `stacks` is the detected stack id(s) — skills load `instructions/stacks/<id>.md` as their baseline. `prHost` is where PRs live — **detect it from the `origin` remote** (`github.com` → `github`, `bitbucket.org` → `bitbucket`, `gitlab.com` → `gitlab`; otherwise ask); `create-pr`/`pr-review`/`fix-pr` use it. For `bitbucket`/`gitlab`, remind the user that PR actions need a token/CLI authenticated (e.g. `BITBUCKET_TOKEN`, or `glab auth login`). `reviewState` is filled the first time `issue-update` transitions an item, then reused. `test.coverageCommands` is optional — `coverage-check` fills it in when it detects the repo's coverage command.
 
 **If the repo has no `CLAUDE.md`:** say so, proceed using the stack profile(s) + detected commands as the baseline, and suggest the user run `/init` (or let the kit propose a minimal `CLAUDE.md`) so future runs are grounded in the repo's own conventions. Never silently assume conventions the repo hasn't stated.
 

--- a/skills/fix-pr/SKILL.md
+++ b/skills/fix-pr/SKILL.md
@@ -11,6 +11,8 @@ Turn findings into commits: every blocking finding gets fixed or explicitly answ
 
 Collect, in this order:
 
+Fetch these from the configured host (`prHost` in `.claude/dev-kit.json`) — commands below are for `github`; for **bitbucket** use the REST API (`/pullrequests/{id}` for comments, `/statuses` for build results) with a token from the environment, and for **gitlab** use `glab mr view/checks`.
+
 1. **CI failures**: `gh pr checks <pr>` — read the failing job logs, not just the status.
 2. **Review comments**: `gh pr view <pr> --comments` and unresolved review threads (`gh api` for review comments when needed).
 3. **Self-review findings** handed over by the caller (e.g. the coding-agent's `pr-review` pass).

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -9,7 +9,7 @@ Produce a high-signal review: findings a reviewer would act on, classified and o
 
 ## Scope the diff
 
-- Reviewing an existing PR: `gh pr diff <pr>` + `gh pr view <pr>` for description and context.
+- Reviewing an existing PR: fetch the diff and description from the configured host (`prHost` in `.claude/dev-kit.json`). **github:** `gh pr diff <pr>` + `gh pr view <pr>`. **bitbucket:** `GET /2.0/repositories/{ws}/{repo}/pullrequests/{id}/diff` and `/pullrequests/{id}` (REST, token from env). **gitlab:** `glab mr diff <id>` + `glab mr view <id>`.
 - Reviewing the working tree (self-review before PR): `git diff` against the base branch, including staged changes.
 - Read the linked ticket's acceptance criteria — a diff can be flawless and still not do what the story asked.
 


### PR DESCRIPTION
Re-targets the Bitbucket/GitLab PR-host work to **main**. The original #5 was stacked on `feat/stack-profiles` and merged into that branch instead of main when #4 landed first, so this content never reached main. Same commits, no rework.

## Contents (= former #5)
- Wizard: "Pull request host" step (GitHub / Bitbucket / GitLab / other) → writes `prHost`.
- create-pr / pr-review / fix-pr: per-host adapters (github `gh`, bitbucket REST, gitlab `glab`).
- dev-kit-setup: detect `prHost` from the origin remote.
- README adapters table; version → 0.8.0.

Bitbucket/GitLab remain iteration-zero / unverified end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)