### PR TITLE
Research-backed enrichment of all 8 stack profiles (v0.9.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fullstack-dev-kit",
-  "version": "0.7.0",
+  "version": "0.9.0",
   "description": "Issue-to-PR workflow kit for any tech stack. Fetch a user story from your tracker (Jira, Linear, GitHub Issues, Azure DevOps) and any linked Figma designs, implement with plan approval, enforce >95% coverage and a security pass, generate e2e tests, open the PR, fix review findings, and move the ticket to review.",
   "license": "Apache-2.0",
   "homepage": "https://github.com/theam/claude-dev-kit",

--- a/instructions/stacks/dotnet.md
+++ b/instructions/stacks/dotnet.md
@@ -5,23 +5,26 @@
 Baseline for .NET projects. The repo's `CLAUDE.md`, `*.sln`, and `*.csproj` settings win over this.
 
 ## Detect
-`*.sln` or `*.csproj`. Test projects usually reference `xunit`, `nunit`, or `MSTest` plus `coverlet`.
+`*.sln` or `*.csproj`. Test projects reference `xunit`, `nunit`, or `MSTest` plus `coverlet` (`coverlet.collector` / `coverlet.msbuild`).
 
 ## Commands
 - Restore/build: `dotnet restore` && `dotnet build`.
-- Lint/format: `dotnet format --verify-no-changes` (plus any analyzers configured).
+- Format: `dotnet format --verify-no-changes` (+ any analyzers).
 - Unit tests: `dotnet test`.
 - Tests with coverage: `dotnet test --collect:"XPlat Code Coverage" --results-directory ./TestResults`
-  - Or coverlet MSBuild: `dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura`.
+  - MSBuild alt: `dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura`
 
 ## Coverage
-- Report: `TestResults/**/coverage.cobertura.xml` (Cobertura). Parse per-file line/branch metrics from it.
-- If the repo defines coverlet settings or a coverage command in `CLAUDE.md`/`.csproj`, prefer those.
+- Report: `TestResults/**/coverage.cobertura.xml` (**Cobertura**) — parse per-file line/branch.
+- Prefer the repo's coverlet settings / `runsettings` if defined in `CLAUDE.md` or the `.csproj`.
+- Multiple test projects: aggregate the Cobertura files across the touched files.
 
 ## E2E
-- Playwright for .NET or Selenium.WebDriver (commonly a separate test project). Reuse existing page models and driver setup.
+- Playwright for .NET or Selenium.WebDriver (usually a separate test project). Reuse existing page models and driver setup.
 
 ## Conventions & gotchas
-- Test naming: `Method_Scenario_ExpectedResult`; one behaviour per test.
+- Test naming `Method_Scenario_ExpectedResult`; one behaviour per test.
 - Responses return DTOs, not entities; validate at the request boundary.
-- Multiple test projects: aggregate the Cobertura files for per-file coverage across the touched files.
+
+## Docs
+Coverlet: <https://github.com/coverlet-coverage/coverlet> · `dotnet test`: <https://learn.microsoft.com/dotnet/core/tools/dotnet-test>

--- a/instructions/stacks/go.md
+++ b/instructions/stacks/go.md
@@ -5,23 +5,26 @@
 Baseline for Go projects. The repo's `CLAUDE.md` and `Makefile` targets win over this.
 
 ## Detect
-`go.mod`. Tests are `*_test.go` files using the standard `testing` package.
+`go.mod`. Tests are `*_test.go` files using the standard `testing` package (often table-driven).
 
 ## Commands
 - Build: `go build ./...`.
-- Lint/vet: `go vet ./...` and `golangci-lint run` if configured; format: `gofmt -l .`.
+- Vet/lint: `go vet ./...` and `golangci-lint run` (if configured); format check: `gofmt -l .`.
 - Unit tests: `go test ./...`.
 - Tests with coverage: `go test ./... -coverprofile=cover.out -covermode=atomic`
-  - Per-package/func summary: `go tool cover -func=cover.out`.
+  - Summary: `go tool cover -func=cover.out` (per-function + total); HTML: `go tool cover -html=cover.out`.
 
 ## Coverage
-- Report: `cover.out` (Go coverprofile). `go tool cover -func` gives per-function and total %; parse it for per-file coverage of touched files.
-- Go coverage is line-based; branch/function metrics aren't native — report line coverage and say so rather than inventing a branch number.
+- Report: `cover.out` (Go coverprofile). Parse per-file/function % from `go tool cover -func`.
+- Go coverage is **line-based**; branch/function metrics aren't native — report line coverage and say so rather than inventing a branch number.
+- `-covermode=atomic` when tests run in parallel; `-coverpkg=./...` to include cross-package coverage.
 
 ## E2E
 - API/integration via `net/http/httptest` and table-driven tests. Web UI (if any) via Playwright/Selenium against the built binary.
 
 ## Conventions & gotchas
-- Table-driven tests, `t.Run` subtests; keep tests in the same package or `_test` package.
+- Table-driven tests with `t.Run` subtests; keep tests in-package or a `_test` package.
 - No unseeded randomness or real clocks — inject them.
-- `-covermode=atomic` when tests run in parallel.
+
+## Docs
+`go test` / cover: <https://go.dev/blog/cover> · golangci-lint: <https://golangci-lint.run>

--- a/instructions/stacks/java.md
+++ b/instructions/stacks/java.md
@@ -1,28 +1,32 @@
-# Java (JVM) — stack profile
+# Java / Kotlin (JVM) — stack profile
 
 > **Iteration zero.** A starting baseline, not yet verified end to end. If you work in this stack, please improve it — corrections and additions are very welcome via PR (see [README](./README.md)).
 
-Baseline for Java/Kotlin JVM projects. The repo's `CLAUDE.md`, `pom.xml`, or Gradle build win over this.
+Baseline for JVM projects. The repo's `CLAUDE.md`, `pom.xml`, or Gradle build win over this.
 
 ## Detect
-`pom.xml` (Maven) or `build.gradle` / `build.gradle.kts` (Gradle). Tests: JUnit 5 / JUnit 4 / TestNG.
+`pom.xml` (Maven) or `build.gradle[.kts]` (Gradle). Tests: JUnit 5 / JUnit 4 / TestNG. Use the wrapper if present (`./mvnw`, `./gradlew`).
 
 ## Commands
-- Build: `mvn -q verify -DskipTests` or `./gradlew build -x test`.
-- Lint/format: Checkstyle / Spotless (`mvn spotless:check` or `./gradlew spotlessCheck`) if configured.
-- Unit tests: `mvn test` or `./gradlew test`.
+- Build: `./mvnw -q verify -DskipTests` or `./gradlew build -x test`.
+- Lint/format: Checkstyle / Spotless (`spotless:check` / `spotlessCheck`) if configured.
+- Unit tests: `./mvnw test` or `./gradlew test`.
 - Tests with coverage (JaCoCo):
-  - Maven: `mvn test` with the JaCoCo plugin → `target/site/jacoco/jacoco.xml`
+  - Maven: `./mvnw test` with the JaCoCo plugin (`prepare-agent` + `report`) → `target/site/jacoco/jacoco.xml`
   - Gradle: `./gradlew test jacocoTestReport` → `build/reports/jacoco/test/jacocoTestReport.xml`
 
 ## Coverage
-- Report: JaCoCo XML (paths above). Parse per-class/line/branch counters. Enable the XML reporter if only HTML is produced.
-- Kotlin projects may use Kover (`./gradlew koverXmlReport` → `build/reports/kover/report.xml`).
+- Report: **JaCoCo XML** (paths above) — parse per-class line/branch counters. Enable the XML reporter if only HTML is generated.
+- Multi-module: Gradle `jacoco-report-aggregation` plugin, or Maven `jacoco:report-aggregate`, for one merged XML.
+- Kotlin projects often use **Kover** (`./gradlew koverXmlReport` → `build/reports/kover/report.xml`).
+- Gate: `jacocoTestCoverageVerification` (Gradle) / `jacoco:check` (Maven).
 
 ## E2E
-- Selenium.WebDriver or Playwright for Java; Rest-Assured for API flows.
+- Selenium WebDriver or Playwright for Java; Rest-Assured for API flows.
 
 ## Conventions & gotchas
-- Tests under `src/test/java`, mirror the package of the class under test.
-- Prefer constructor injection + real in-memory collaborators over deep mocking.
-- Gradle vs Maven: detect from the build file present and use its wrapper (`./gradlew`, `./mvnw`) when available.
+- Tests under `src/test/java`, mirroring the class's package.
+- Prefer constructor injection + in-memory collaborators over deep mocking.
+
+## Docs
+JaCoCo (Gradle): <https://docs.gradle.org/current/userguide/jacoco_plugin.html> · Kover: <https://github.com/Kotlin/kotlinx-kover>

--- a/instructions/stacks/node.md
+++ b/instructions/stacks/node.md
@@ -5,27 +5,28 @@
 Baseline for Node projects. The repo's `CLAUDE.md` and `package.json` scripts win over this.
 
 ## Detect
-`package.json`. TypeScript if `tsconfig.json` is present. Test runner from devDependencies (`jest`, `vitest`, `mocha`) or the `test` script.
+`package.json` (+ `tsconfig.json` for TypeScript). Runner from devDependencies / the `test` script: `vitest`, `jest`, or `mocha`. Match the package manager to the lockfile (`package-lock.json`→npm, `pnpm-lock.yaml`→pnpm, `yarn.lock`→yarn).
 
 ## Commands
-- Install: `npm ci` (or `pnpm i` / `yarn` — match the lockfile present).
-- Build: `npm run build` if defined.
-- Lint: `npm run lint` (usually ESLint); type-check: `npx tsc --noEmit`.
+- Install: `npm ci` (or `pnpm i --frozen-lockfile` / `yarn --immutable`).
+- Lint: `npm run lint` (ESLint); types: `npx tsc --noEmit`.
 - Unit tests: `npm test`.
-- Tests with coverage:
-  - Jest: `npx jest --coverage`
+- Tests with coverage (prefer a `test:coverage` script if present):
   - Vitest: `npx vitest run --coverage`
-  - Prefer a repo script if present: `npm run test:coverage`.
+  - Jest: `npx jest --coverage`
 
 ## Coverage
-- Report: `coverage/lcov.info` (lcov) and/or `coverage/coverage-summary.json` (json-summary). Enable json-summary/lcov reporters if missing.
-- Per-file line/branch/function metrics come straight from `coverage-summary.json` or the `lcov.info` records.
+- Vitest provider: **`v8`** (default, fast, zero extra deps) or **`istanbul`** (most precise branch counts, widest reporters). Jest uses istanbul-style.
+- Report: enable the **`lcov`** reporter → `coverage/lcov.info` (parse per-file line/branch/function), plus `text-summary` for CI logs. `json-summary` → `coverage/coverage-summary.json` is easiest to read programmatically.
+- Set `coverage.all: true` + an `include` glob so untested files count as 0% — honest totals, not a misleading 100%.
 
 ## E2E
-- Playwright (`npx playwright test`) or Cypress (`npx cypress run`). Reuse the existing config and page objects; never introduce a second framework.
+- Playwright (`npx playwright test`) or Cypress (`npx cypress run`). Reuse the existing config/page objects; never add a second framework.
 
 ## Conventions & gotchas
-- Never use `any` in tests; no `require()` in TS test files.
+- No `any` in tests; no `require()` in TS test files.
 - Mock at boundaries (HTTP, db, clock), not between same-layer collaborators.
-- Match the package manager to the lockfile (`package-lock.json` → npm, `pnpm-lock.yaml` → pnpm, `yarn.lock` → yarn).
-- Monorepos: run tests per workspace/package and merge per-file coverage.
+- Monorepos: run per workspace and merge per-file coverage.
+
+## Docs
+Vitest coverage: <https://vitest.dev/guide/coverage> · Playwright: <https://playwright.dev>

--- a/instructions/stacks/php.md
+++ b/instructions/stacks/php.md
@@ -5,23 +5,30 @@
 Baseline for PHP projects (Laravel, Symfony, or plain). The repo's `CLAUDE.md` and `composer.json` scripts win over this.
 
 ## Detect
-`composer.json`. Tests: PHPUnit (`phpunit.xml`/`phpunit.xml.dist`) or Pest. Framework: Laravel (`artisan`) / Symfony (`bin/console`).
+`composer.json`. Tests: PHPUnit (`phpunit.xml[.dist]`) or Pest (`Pest.php`). Framework: Laravel (`artisan`) or Symfony (`bin/console`).
 
 ## Commands
-- Install: `composer install`.
-- Lint/static analysis: `vendor/bin/php-cs-fixer fix --dry-run` / `vendor/bin/phpcs`; `vendor/bin/phpstan analyse` or `vendor/bin/psalm` if configured.
-- Unit tests: `vendor/bin/phpunit` (or `vendor/bin/pest`, or `php artisan test` on Laravel).
-- Tests with coverage: `vendor/bin/phpunit --coverage-clover coverage.xml`
-  - Pest: `vendor/bin/pest --coverage --coverage-clover coverage.xml`.
+- Install: `composer install`
+- Static analysis: `vendor/bin/phpstan analyse` or `vendor/bin/psalm` (if configured)
+- Style: `vendor/bin/php-cs-fixer fix --dry-run --diff` or `vendor/bin/phpcs`
+- Unit tests: `vendor/bin/phpunit` · `vendor/bin/pest` · Laravel `php artisan test`
+- Tests with coverage: `XDEBUG_MODE=coverage vendor/bin/phpunit --coverage-clover coverage.xml`
+  (Pest: `vendor/bin/pest --coverage --coverage-clover coverage.xml`)
 
 ## Coverage
-- Report: `coverage.xml` (**Clover** format). Parse per-file line/branch metrics from the `<file>` / `<metrics>` nodes.
-- **Prerequisite:** coverage needs a driver — **Xdebug** (`XDEBUG_MODE=coverage`) or **PCOV** installed. Without it PHPUnit reports no coverage; detect this and say so rather than reporting 0%.
+- **A coverage driver is required** or PHPUnit reports *no* coverage — detect its absence and say so rather than reporting 0%:
+  - **PCOV** — line coverage only, 2–5× faster; best for CI.
+  - **Xdebug 3** — line **and branch** coverage (needed for a branch gate); requires `XDEBUG_MODE=coverage`, much slower.
+- Report: `coverage.xml` (**Clover**) — parse per-file line/branch from `<file>`/`<metrics>`. `--coverage-cobertura` is an alternative format.
+- Scope covered files via `<source>` in `phpunit.xml` (best practice) to avoid vendor noise.
 
 ## E2E
-- Laravel Dusk or Codeception for full-stack; Playwright/Cypress for a decoupled frontend; API flows via PHPUnit feature tests against the app.
+- Laravel: feature tests (HTTP) + **Dusk** (browser). Symfony: **Panther**. Codeception is common project-wide. Decoupled SPA frontend: Playwright/Cypress in its own tree.
 
 ## Conventions & gotchas
-- PSR-4 layout; tests under `tests/` (`tests/Unit`, `tests/Feature`).
-- Laravel: use `RefreshDatabase`/transactions for isolation; factories over shared fixtures.
-- Confirm the coverage driver is present before trusting (or failing) the 95% gate.
+- PSR-4; tests under `tests/` (`tests/Unit`, `tests/Feature`).
+- Laravel: `RefreshDatabase`/transactions for isolation; factories over shared fixtures.
+- If only PCOV is present, branch coverage isn't available — report line coverage and note it.
+
+## Docs
+PHPUnit coverage: <https://docs.phpunit.de/en/12.5/code-coverage.html> · Pest: <https://pestphp.com/docs/test-coverage>

--- a/instructions/stacks/python.md
+++ b/instructions/stacks/python.md
@@ -2,27 +2,29 @@
 
 > **Iteration zero.** A starting baseline, not yet verified end to end. If you work in this stack, please improve it — corrections and additions are very welcome via PR (see [README](./README.md)).
 
-Baseline for Python projects. The repo's `CLAUDE.md`, `pyproject.toml`, or `tox.ini` win over this.
+Baseline for Python projects. The repo's `CLAUDE.md` and `pyproject.toml` win over this.
 
 ## Detect
-`pyproject.toml`, `setup.py`, `setup.cfg`, or `requirements*.txt`. Test framework: `pytest` (default) or `unittest`.
+`pyproject.toml`, `setup.py`/`setup.cfg`, or `requirements*.txt`. Test framework: `pytest` (default) or `unittest`. Env tool: venv / poetry / uv / pdm — use the project's.
 
 ## Commands
-- Install: `pip install -e .[dev]` or `pip install -r requirements-dev.txt`; use `poetry install` / `uv sync` if that's the project's tool.
-- Lint/format: `ruff check` (or `flake8`) and `ruff format` / `black`; type-check: `mypy` if configured.
+- Install: `pip install -e .[dev]` / `poetry install` / `uv sync` (match the project).
+- Lint + format: `ruff check` and `ruff format --check` (or flake8/black); types: `mypy` if configured.
 - Unit tests: `pytest`.
-- Tests with coverage: `pytest --cov --cov-report=xml --cov-report=term-missing`
-  - `--cov=<package>` to scope to the source package.
+- Tests with coverage: `pytest --cov=<package> --cov-branch --cov-report=xml --cov-report=term-missing`
 
 ## Coverage
-- Report: `coverage.xml` (Cobertura format) — the default for `coverage-check` to parse. `.coverage` (SQLite) or `coverage json` are alternatives.
-- `--cov-report=term-missing` lists uncovered lines inline, useful for closing gaps.
+- `pytest-cov` wraps `coverage.py`. `--cov-report=xml` → `coverage.xml` (**Cobertura**), the default for the gate to parse; `--cov-branch` adds branch coverage; `--cov-report=term-missing` lists uncovered lines.
+- Enforce inline with `--cov-fail-under=95`. Configure `[tool.coverage]` in `pyproject.toml`.
+- Combining across parallel/CI-matrix runs needs `coverage combine` — watch for under-reporting if skipped.
 
 ## E2E
-- Web UI: Playwright for Python (`pytest` + `playwright`) or Selenium. API: `pytest` against a running app or `TestClient` (FastAPI) / Django test client.
+- Web UI: Playwright for Python or Selenium. API: `pytest` against a running app, or the framework's test client (FastAPI `TestClient`, Django test client).
 
 ## Conventions & gotchas
-- Tests in `tests/`, files `test_*.py`, one behaviour per test.
-- Use fixtures; avoid module-level mutable state shared across tests.
-- Respect the project's env manager (venv / poetry / uv / conda) — don't install globally.
-- Coverage needs the source importable; run from the repo root with the right `PYTHONPATH`/install.
+- Tests in `tests/`, files `test_*.py`, one behaviour per test; fixtures over module-level mutable state.
+- Coverage needs the source importable — run from repo root with the package installed (`-e`).
+- Don't install globally; respect the project's env manager.
+
+## Docs
+pytest-cov: <https://pytest-cov.readthedocs.io> · coverage.py: <https://coverage.readthedocs.io>

--- a/instructions/stacks/ruby.md
+++ b/instructions/stacks/ruby.md
@@ -11,16 +11,20 @@ Baseline for Ruby / Rails projects. The repo's `CLAUDE.md` and `Gemfile` win ove
 - Install: `bundle install`.
 - Lint: `bundle exec rubocop`.
 - Unit tests: `bundle exec rspec` or `bin/rails test`.
-- Tests with coverage: run the suite with **SimpleCov** enabled (add `require 'simplecov'; SimpleCov.start` at the top of `spec/spec_helper.rb` or `test/test_helper.rb` if missing).
+- Tests with coverage: run the suite with **SimpleCov** enabled (add `require 'simplecov'; SimpleCov.start 'rails'` at the very top of `spec/spec_helper.rb` / `test/test_helper.rb` if missing).
 
 ## Coverage
-- Report: `coverage/.resultset.json` and `coverage/coverage.json` (SimpleCov). Parse per-file line coverage from there.
-- For a machine-friendly format, add `simplecov-lcov` → `coverage/lcov.info`. SimpleCov is line-based (no native branch coverage unless `enable_coverage :branch` is set).
+- SimpleCov default output: `coverage/.resultset.json` + an HTML report (line-based).
+- For a machine-parseable file, add a formatter gem: **`simplecov-cobertura`** → `coverage/coverage.xml` (Cobertura, recommended) or `simplecov-json` → `coverage/coverage.json`. (`simplecov-lcov` exists but the lcov format is being retired by some tools — prefer Cobertura/JSON.)
+- Branch coverage: `SimpleCov.start { enable_coverage :branch }`. Without it, report line coverage and say so.
 
 ## E2E
-- Rails system tests (Capybara + Selenium/`cuprite`), or Playwright/Cypress for a decoupled frontend.
+- Rails system tests (Capybara + Selenium or `cuprite`), or Playwright/Cypress for a decoupled frontend.
 
 ## Conventions & gotchas
-- RSpec: `describe`/`context`/`it` with behaviour-focused names; use factories (FactoryBot), not fixtures with shared mutable state.
-- Enable SimpleCov before the app loads or coverage under-reports.
-- Rails: use `ActiveRecord` transactions / `database_cleaner` for isolation.
+- **SimpleCov must start before the app loads** or coverage under-reports.
+- RSpec: `describe`/`context`/`it` with behaviour-focused names; FactoryBot over shared fixtures.
+- Rails: transactions / `database_cleaner` for isolation.
+
+## Docs
+SimpleCov: <https://github.com/simplecov-ruby/simplecov>

--- a/instructions/stacks/rust.md
+++ b/instructions/stacks/rust.md
@@ -5,23 +5,26 @@
 Baseline for Rust projects. The repo's `CLAUDE.md` and `Cargo.toml` win over this.
 
 ## Detect
-`Cargo.toml`. Tests are `#[test]` functions (unit, in-module) and integration tests under `tests/`.
+`Cargo.toml`. Tests are `#[test]` functions (unit, in-module) and integration tests under `tests/`. `nextest` if configured.
 
 ## Commands
 - Build: `cargo build`.
 - Lint/format: `cargo clippy -- -D warnings` and `cargo fmt --check`.
-- Unit tests: `cargo test`.
-- Tests with coverage (prefer `cargo-llvm-cov`): `cargo llvm-cov --lcov --output-path lcov.info`
-  - Alternative: `cargo tarpaulin --out Xml` → `cobertura.xml`.
+- Unit tests: `cargo test` (or `cargo nextest run`).
+- Tests with coverage (**cargo-llvm-cov** — the current ecosystem standard): `cargo llvm-cov --lcov --output-path lcov.info`
 
 ## Coverage
-- Report: `lcov.info` (lcov) from llvm-cov, or `cobertura.xml` from tarpaulin. Parse per-file line/region coverage.
-- `cargo llvm-cov --summary-only` prints totals; the tool requires the `llvm-tools-preview` component.
+- **cargo-llvm-cov** uses LLVM source-based instrumentation (line + region + branch, cross-platform, works with `cargo test`/`nextest`). Prefer it over tarpaulin (older, ptrace-based, Linux-x86_64 only).
+- Report: `lcov.info` (lcov) — parse per-file line/region coverage. `--summary-only` prints totals. Needs the `llvm-tools-preview` component.
+- Alternative: `cargo tarpaulin --out Xml` → `cobertura.xml`.
 
 ## E2E
-- Less common; for web services, integration tests under `tests/` hitting a spawned server, or Playwright/Selenium against the built binary for any UI.
+- Uncommon; for services, integration tests under `tests/` against a spawned server. UI (if any) via Playwright/Selenium against the built binary.
 
 ## Conventions & gotchas
-- Unit tests live in a `#[cfg(test)] mod tests` block next to the code; integration tests in `tests/`.
-- Deterministic tests: inject clocks/RNG, no reliance on wall-clock or thread ordering.
+- Unit tests in a `#[cfg(test)] mod tests` block next to the code; integration tests in `tests/`.
+- Deterministic: inject clocks/RNG; no reliance on wall-clock or thread ordering.
 - Workspaces: run coverage per crate and aggregate for the touched files.
+
+## Docs
+cargo-llvm-cov: <https://github.com/taiki-e/cargo-llvm-cov>


### PR DESCRIPTION
Enriches every stack profile with **verified, current tooling** — following the agreed trade-off: **precision over length**. Each profile stays ~30-34 lines (small token cost, and the agent loads only the *detected* stack's profile per run, not all 8).

## What changed (per profile)
- **node** — vitest `v8` vs `istanbul` provider, `lcov`/`json-summary` reporters, `coverage.all` for honest totals.
- **python** — `pytest --cov-branch --cov-report=xml` (Cobertura), `--cov-fail-under`, parallel-combine caveat.
- **java** — retitled *Java/Kotlin*; JaCoCo Maven/Gradle report paths, multi-module aggregation, Kover, gate goals.
- **ruby** — SimpleCov resultset + `simplecov-cobertura`/`json` (lcov being retired), branch coverage, start-before-load gotcha.
- **rust** — `cargo-llvm-cov` as the current ecosystem standard (region/branch, cross-platform) vs tarpaulin.
- **dotnet** — coverlet XPlat/MSBuild → Cobertura, runsettings, multi-project aggregation.
- **go** — coverprofile + `go tool cover`, line-only caveat, `-covermode=atomic`/`-coverpkg`.
- **php** — PCOV vs Xdebug (branch), Clover/Cobertura, `<source>` scoping.
- Each ends with an **official-docs link** so depth lives upstream, not inline.

Sourced from current (2026) tooling docs/guides. Still iteration-zero (banner kept) — verified for *accuracy*, not yet run end to end per stack.

## Merge order
Bumps to **0.9.0**. Merge #6 (Bitbucket, 0.8.0) **first**; then this — expect only a one-line `plugin.json` version conflict to resolve if they cross.

🤖 Generated with [Claude Code](https://claude.com/claude-code)