### PR TITLE
create-dev-kit: npm publish config + package README

### DIFF
--- a/packages/create-dev-kit/README.md
+++ b/packages/create-dev-kit/README.md
@@ -1,0 +1,39 @@
+# @theam/create-dev-kit
+
+Interactive setup for the [**claude-dev-kit**](https://github.com/theam/claude-dev-kit) Claude Code plugin — an issue-to-PR workflow with enforced quality gates, for any tech stack.
+
+```bash
+npm create @theam/dev-kit
+```
+
+Zero dependencies (Node built-ins only), so it's trivial to audit before you run it.
+
+## What it does
+
+Walks you through setup and writes the config, then installs the plugin:
+
+1. **Issue tracker** — Jira / Linear / GitHub Issues / Azure DevOps / none (with a hint on how to connect its MCP/CLI).
+2. **Pull request host** — GitHub / Bitbucket / GitLab / other.
+3. **Design** — whether you link Figma in tickets.
+4. **Telemetry** — shows exactly what anonymous usage data would be collected and lets you **opt in or out** (off by default).
+5. **Organisation** — an optional label to attribute your usage (company-level, never a person).
+
+It writes:
+
+- `.claude/dev-kit.json` in the repo (tracker, PR host, Figma, org) — commit it; shared by your team.
+- `~/.claude/dev-kit-telemetry/config.json` (per user, private) — your telemetry choice.
+
+Then it can run the `claude plugin` install commands for you.
+
+## Requirements
+
+- [Claude Code](https://code.claude.com) (`claude --version`).
+- The relevant CLI/MCP for your tracker & PR host (the wizard tells you which).
+
+## Privacy
+
+Telemetry is **off by default** and, if enabled, sends only anonymous token counts via a relay — never prompts, code, file names, ticket content, emails, or your IP. Full details: [TELEMETRY.md](https://github.com/theam/claude-dev-kit/blob/main/TELEMETRY.md).
+
+## License
+
+[Apache 2.0](https://github.com/theam/claude-dev-kit/blob/main/LICENSE) © The Agile Monkeys.

--- a/packages/create-dev-kit/package.json
+++ b/packages/create-dev-kit/package.json
@@ -5,8 +5,9 @@
   "license": "Apache-2.0",
   "type": "module",
   "bin": { "create-dev-kit": "index.mjs" },
-  "files": ["index.mjs"],
+  "files": ["index.mjs", "README.md"],
   "engines": { "node": ">=18" },
+  "publishConfig": { "access": "public" },
   "homepage": "https://github.com/theam/claude-dev-kit",
   "repository": { "type": "git", "url": "https://github.com/theam/claude-dev-kit.git", "directory": "packages/create-dev-kit" },
   "keywords": ["claude", "claude-code", "dev-kit", "scaffold", "setup"]


### PR DESCRIPTION
Smooths the first npm publish of `@theam/create-dev-kit`.

- **`publishConfig.access: public`** — scoped packages default to restricted; this makes `npm publish` do the right thing without remembering `--access public`.
- **Package `README.md`** — the npm listing page currently would show only the package.json description; this gives it a proper page (usage, what it writes, requirements, privacy). Added to `files` and confirmed via `npm pack --dry-run` (3 files: index.mjs, README.md, package.json).

No version/behaviour change to the plugin. The package stays at `0.1.0` for its first publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)