### PR TITLE
Angular, React, Vue frontend stack profiles (v0.10.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fullstack-dev-kit",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Issue-to-PR workflow kit for any tech stack. Fetch a user story from your tracker (Jira, Linear, GitHub Issues, Azure DevOps) and any linked Figma designs, implement with plan approval, enforce >95% coverage and a security pass, generate e2e tests, open the PR, fix review findings, and move the ticket to review.",
   "license": "Apache-2.0",
   "homepage": "https://github.com/theam/claude-dev-kit",

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Interactive setup — tracker, Figma, telemetry consent, org — then it install
 
 The kit carries **no assumptions about language, framework, or test runner**. It reads everything stack-specific — build/test/lint/coverage commands, architecture conventions, and any implementer subagents — from the **consuming repo's `CLAUDE.md` and `.claude/`**, and detects conventions from the project when they aren't declared.
 
-It ships **baseline "iteration zero" profiles** for common stacks in [`instructions/stacks/`](instructions/stacks/) — **node, python, dotnet, java, go, ruby, php, rust** — giving each one usable coverage/e2e/lint commands out of the box. Your `CLAUDE.md` always overrides them, and adding a stack is one markdown file (see [CONTRIBUTING](CONTRIBUTING.md#adding-or-improving-a-stack-profile)). These profiles are early and community-refined — treat an unlisted or unverified stack as "should work, help us confirm" rather than guaranteed.
+It ships **baseline "iteration zero" profiles** for common stacks in [`instructions/stacks/`](instructions/stacks/) — **node, angular, react, vue, python, dotnet, java, go, ruby, php, rust** — giving each one usable coverage/e2e/lint commands out of the box. Your `CLAUDE.md` always overrides them, and adding a stack is one markdown file (see [CONTRIBUTING](CONTRIBUTING.md#adding-or-improving-a-stack-profile)). These profiles are early and community-refined — treat an unlisted or unverified stack as "should work, help us confirm" rather than guaranteed.
 
 It integrates with your tools through **adapters**, not hardcoded dependencies:
 

--- a/instructions/stacks/README.md
+++ b/instructions/stacks/README.md
@@ -53,5 +53,5 @@ Xdebug/PCOV for coverage), and keep it to what the kit actually needs: how to ru
 tests, get coverage, run e2e, and the conventions a reviewer would expect. See the
 main [CONTRIBUTING.md](../../CONTRIBUTING.md).
 
-Current profiles: `dotnet`, `go`, `java`, `node`, `php`, `python`, `ruby`, `rust`.
+Current profiles: `angular`, `dotnet`, `go`, `java`, `node`, `php`, `python`, `react`, `ruby`, `rust`, `vue`. (Frontend frameworks `angular`/`react`/`vue` build on `node` and add framework-specific test/coverage/e2e detail.)
 Everything here is iteration zero — corrections from people who work in the stack daily are the most valuable contribution.

--- a/instructions/stacks/angular.md
+++ b/instructions/stacks/angular.md
@@ -1,0 +1,31 @@
+# Angular — stack profile
+
+> **Iteration zero.** A starting baseline, not yet verified end to end. If you work in this stack, please improve it — corrections and additions are very welcome via PR (see [README](./README.md)).
+
+Baseline for Angular projects. The repo's `CLAUDE.md` and `angular.json` win. Shares the JS/TS toolchain — see [`node`](./node.md) for package-manager/lint details.
+
+## Detect
+`angular.json`. Runner (check the `test` builder in `angular.json`): **Vitest** (Angular v21+ default, `@angular/build:unit-test`), **Karma/Jasmine** (legacy, now deprecated), or **jest-preset-angular**.
+
+## Commands
+- Install: `npm ci`
+- Lint: `ng lint` (ESLint); types: `tsc --noEmit`
+- Unit tests: `ng test --no-watch`  (add `CI=true` so it exits — default `ng test` watches)
+- Tests with coverage:
+  - Vitest builder (v21+): `ng test --no-watch --coverage`
+  - Legacy Karma: `ng test --no-watch --code-coverage`
+
+## Coverage
+- Report: `coverage/**/lcov.info` (parse per-file line/branch). Coverage is first-class in the CLI.
+- **Check the builder first** — the flag differs (`--coverage` for Vitest vs `--code-coverage` for Karma). Karma is deprecated; new projects are on Vitest. Browser tests: `@vitest/browser-playwright` via `angular.json`.
+
+## E2E
+- Protractor is retired → **Playwright** or **Cypress**. `ng e2e` prompts to pick a runner.
+
+## Conventions & gotchas
+- Specs `*.spec.ts` beside the component; `TestBed` for component setup.
+- `provideHttpClientTesting()` / harnesses over deep mocks.
+- Always pass `--no-watch`/`CI=true` in automation, or the run hangs.
+
+## Docs
+Testing: <https://angular.dev/guide/testing> · Migrating to Vitest: <https://angular.dev/guide/testing/migrating-to-vitest>

--- a/instructions/stacks/react.md
+++ b/instructions/stacks/react.md
@@ -1,0 +1,31 @@
+# React — stack profile
+
+> **Iteration zero.** A starting baseline, not yet verified end to end. If you work in this stack, please improve it — corrections and additions are very welcome via PR (see [README](./README.md)).
+
+Baseline for React projects. The repo's `CLAUDE.md` wins. Shares the JS/TS toolchain — see [`node`](./node.md) for package-manager/lint details.
+
+## Detect
+`react` / `react-dom` in `package.json`. Bundler/meta-framework: Vite (`vite.config.*`), Next.js (`next.config.*`), or legacy CRA (`react-scripts` — end-of-life).
+
+## Commands
+- Install: `npm ci`
+- Lint: `npm run lint` (ESLint); types: `tsc --noEmit`
+- Unit tests: `npm test`
+- Tests with coverage:
+  - Vitest (Vite / new projects): `npx vitest run --coverage`
+  - Jest (existing suites): `npx jest --coverage`
+  - Next.js: match the configured runner.
+
+## Coverage
+- Report: `coverage/lcov.info` (parse per-file line/branch/function). Vitest `v8`/`istanbul` or Jest istanbul — enable the `lcov` reporter.
+- New projects → **Vitest** (default in 2026); existing Jest is fine. CRA is EOL — migrate off it.
+
+## E2E
+- **Playwright** (`npx playwright test`) or **Cypress**. Next.js: same.
+
+## Conventions & gotchas
+- **`@testing-library/react`** — query by role/label/visible text; test behaviour, not internals. **MSW** for network mocking.
+- No Enzyme / no asserting on implementation details in new code.
+
+## Docs
+React Testing Library: <https://testing-library.com/docs/react-testing-library/intro> · Vitest coverage: <https://vitest.dev/guide/coverage>

--- a/instructions/stacks/vue.md
+++ b/instructions/stacks/vue.md
@@ -1,0 +1,27 @@
+# Vue — stack profile
+
+> **Iteration zero.** A starting baseline, not yet verified end to end. If you work in this stack, please improve it — corrections and additions are very welcome via PR (see [README](./README.md)).
+
+Baseline for Vue 3 projects. The repo's `CLAUDE.md` wins. Shares the JS/TS toolchain — see [`node`](./node.md) for package-manager/lint details.
+
+## Detect
+`vue` in `package.json` (+ `@vitejs/plugin-vue` / `vite.config.*`, or `vue.config.js` for legacy Vue CLI). `create-vue` scaffolds Vitest + an e2e choice.
+
+## Commands
+- Install: `npm ci`
+- Lint: `npm run lint` (ESLint); types: `vue-tsc --noEmit`  (not plain `tsc` — needs template type-checking)
+- Unit tests: `npm run test:unit`  (Vitest)
+- Tests with coverage: `npx vitest run --coverage`
+
+## Coverage
+- Report: `coverage/lcov.info` (parse per-file line/branch/function). Vitest `v8`/`istanbul` provider — enable the `lcov` reporter.
+
+## E2E
+- **Playwright** or **Cypress** (`create-vue` offers both, plus Nightwatch). Component tests: `@vue/test-utils` in jsdom (fast) or Playwright/Vitest browser mode (real browser).
+
+## Conventions & gotchas
+- **`@vue/test-utils`** is the official unit helper (`mount`/`shallowMount`); query by role/text.
+- Vitest is Vite-native — it reuses the project's Vite config/plugins, so setup is minimal.
+
+## Docs
+Vue testing: <https://vuejs.org/guide/scaling-up/testing> · Vue Test Utils: <https://test-utils.vuejs.org>

--- a/skills/dev-kit-setup/SKILL.md
+++ b/skills/dev-kit-setup/SKILL.md
@@ -48,6 +48,9 @@ Identify the tech stack from the project's files so the kit can load the right b
 | Signal | Stack id |
 |---|---|
 | `package.json` | `node` |
+| `angular.json` | `angular` |
+| `react` / `react-dom` in `package.json` | `react` |
+| `vue` in `package.json` | `vue` |
 | `pyproject.toml` / `requirements*.txt` | `python` |
 | `*.csproj` / `*.sln` | `dotnet` |
 | `pom.xml` / `build.gradle` | `java` |
@@ -56,7 +59,7 @@ Identify the tech stack from the project's files so the kit can load the right b
 | `composer.json` | `php` |
 | `Cargo.toml` | `rust` |
 
-A monorepo may match several — record all of them. If nothing matches a shipped profile, record the closest label anyway and tell the user there is no stack profile yet (the kit still works from the repo's `CLAUDE.md` and generic rules — and contributing `instructions/stacks/<id>.md` is one small PR).
+A JS/TS frontend matches **both** `node` and its framework — prefer the **more specific** one (`angular`/`react`/`vue`); those profiles reference `node` for the shared toolchain. A monorepo may match several — record all of them (e.g. `["dotnet", "angular"]`). If nothing matches a shipped profile, record the closest label anyway and tell the user there is no stack profile yet (the kit still works from the repo's `CLAUDE.md` and generic rules — and contributing `instructions/stacks/<id>.md` is one small PR).
 
 ## 4. Persist
 


### PR DESCRIPTION
Frontend frameworks were implicitly under `node`; this gives the three most-used their own profiles with framework-specific detail. Research-backed / current (2026), each ~27-31 lines (only the detected profile loads per run).

- **angular** — Vitest is the **v21+ default** (Karma deprecated): `ng test --coverage` vs legacy `--code-coverage`; `--no-watch`/`CI=true` gotcha; Protractor→Playwright/Cypress.
- **react** — Vitest (new) vs Jest (existing); React Testing Library "test behaviour, not internals"; MSW; CRA is EOL.
- **vue** — Vitest + `@vue/test-utils`; `vue-tsc` for template types; `create-vue` e2e choices.

Wiring:
- All three **build on `node`** (linked) and add only the framework-specific bits — no duplication.
- `dev-kit-setup` detects `angular.json` / `react` / `vue` and **prefers the framework profile** over `node` (a JS repo matches both). README + stacks/README profile lists updated.

Version → **0.10.0**. Everything else (Python, PHP, Go, etc.) stays under its language profile as agreed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)