### PR TITLE
Telemetry: track the Claude Code surface (entrypoint) — v0.11.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fullstack-dev-kit",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Issue-to-PR workflow kit for any tech stack. Fetch a user story from your tracker (Jira, Linear, GitHub Issues, Azure DevOps) and any linked Figma designs, implement with plan approval, enforce >95% coverage and a security pass, generate e2e tests, open the PR, fix review findings, and move the ticket to review.",
   "license": "Apache-2.0",
   "homepage": "https://github.com/theam/claude-dev-kit",

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -49,6 +49,7 @@ One POST at `SessionEnd`, only for sessions where the kit ran, matching the cont
     "kit_version": "0.6.0",
     "claude_code_version": "2.1.x",
     "os": "darwin",
+    "entrypoint": "claude-vscode",
     "tracker_type": "jira",
     "duration_bucket": "5m_to_15m",
     "tokens_input": 48210,
@@ -61,6 +62,7 @@ One POST at `SessionEnd`, only for sessions where the kit ran, matching the cont
 ```
 
 - `install_id` — random UUID stored at `~/.claude/dev-kit-telemetry/config.json`. Not derived from your machine, user, or repo. Delete the file to reset.
+- `entrypoint` — which Claude Code surface ran the pipeline (`cli`, `claude-vscode`, `claude-desktop`, `intellij`, `sdk`, …), from `CLAUDE_CODE_ENTRYPOINT`. A short non-personal slug.
 - `tracker_type` — the *category* (jira / linear / github / azure), never the site, project, or instance.
 - `duration_bucket` — a coarse range, never a raw timestamp.
 - `tokens_*` — sums parsed from the session transcript's `usage` fields.

--- a/packages/telemetry-relay/contract.v1.json
+++ b/packages/telemetry-relay/contract.v1.json
@@ -8,6 +8,7 @@
     "kit_version": { "type": "version" },
     "claude_code_version": { "type": "version", "optional": true },
     "os": { "type": "enum", "values": ["darwin", "linux", "win32"] },
+    "entrypoint": { "type": "string", "maxLength": 32, "optional": true },
     "tracker_type": { "type": "enum", "values": ["jira", "linear", "github", "azure"], "optional": true },
     "org": { "type": "string", "maxLength": 64, "optional": true },
     "duration_bucket": { "type": "enum", "values": ["lt_1m", "1m_to_5m", "5m_to_15m", "15m_to_1h", "gte_1h"], "optional": true },

--- a/scripts/telemetry.mjs
+++ b/scripts/telemetry.mjs
@@ -121,6 +121,11 @@ try {
     kitVersion = JSON.parse(readFileSync(join(root, '.claude-plugin', 'plugin.json'), 'utf8')).version;
   } catch { /* ignore */ }
 
+  // Which Claude Code surface ran the pipeline (cli, claude-vscode, claude-desktop,
+  // intellij, sdk, …). A short, non-personal slug — never anything identifying.
+  const entrypoint = (process.env.CLAUDE_CODE_ENTRYPOINT || '')
+    .toLowerCase().replace(/[^a-z0-9-]/g, '').slice(0, 32) || undefined;
+
   // --- Send the sanitized event to the relay (no API key here) -------------
   const payload = {
     schema_version: 1,
@@ -132,6 +137,7 @@ try {
       kit_version: kitVersion,
       claude_code_version: event.version || undefined,
       os: process.platform,
+      entrypoint, // Claude Code surface (cli / vscode / desktop / …)
       tracker_type: trackerType,
       duration_bucket: durationBucket,
       tokens_input: tok.input,

--- a/telemetry/contract.v1.json
+++ b/telemetry/contract.v1.json
@@ -8,6 +8,7 @@
     "kit_version": { "type": "version" },
     "claude_code_version": { "type": "version", "optional": true },
     "os": { "type": "enum", "values": ["darwin", "linux", "win32"] },
+    "entrypoint": { "type": "string", "maxLength": 32, "optional": true },
     "tracker_type": { "type": "enum", "values": ["jira", "linear", "github", "azure"], "optional": true },
     "org": { "type": "string", "maxLength": 64, "optional": true },
     "duration_bucket": { "type": "enum", "values": ["lt_1m", "1m_to_5m", "5m_to_15m", "15m_to_1h", "gte_1h"], "optional": true },


### PR DESCRIPTION
Answers "where is the pipeline run from?" — adds an anonymous **`entrypoint`** property alongside the token counts.

- Source: **`CLAUDE_CODE_ENTRYPOINT`** (the authoritative signal) — values like `cli`, `claude-vscode`, `claude-desktop`, `intellij`, `sdk`. Slugified, capped at 32 chars, no PII.
- Contract updated (root + relay copy) to allow `entrypoint`; TELEMETRY.md documents it.
- Verified end to end: the hook emits it and the relay sanitizes + forwards it to PostHog.

Now the telemetry captures: token counts, session-duration bucket, OS, tracker category, org (opt-in), and **surface**. Version → 0.11.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)