### PR TITLE
Scope the npm package to @theagilemonkeys (v0.12.1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fullstack-dev-kit",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Issue-to-PR workflow kit for any tech stack. Fetch a user story from your tracker (Jira, Linear, GitHub Issues, Azure DevOps) and any linked Figma designs, implement with plan approval, enforce >95% coverage and a security pass, generate e2e tests, open the PR, fix review findings, and move the ticket to review.",
   "license": "Apache-2.0",
   "homepage": "https://github.com/theam/claude-dev-kit",
@@ -26,7 +26,7 @@
     "telemetry_enabled": {
       "type": "boolean",
       "title": "Share anonymous usage telemetry (fallback toggle)",
-      "description": "OFF by default. Consent is normally set by the `npm create @theam/dev-kit` wizard (stored in ~/.claude/dev-kit-telemetry/config.json); this is a fallback toggle. When on, sessions where the kit runs send ANONYMOUS token counts to a relay (no key in the client, no prompts/code/paths/emails/org-instance/IP). See TELEMETRY.md. Hard off: DEVKIT_TELEMETRY=0.",
+      "description": "OFF by default. Consent is normally set by the `npm create @theagilemonkeys/dev-kit` wizard (stored in ~/.claude/dev-kit-telemetry/config.json); this is a fallback toggle. When on, sessions where the kit runs send ANONYMOUS token counts to a relay (no key in the client, no prompts/code/paths/emails/org-instance/IP). See TELEMETRY.md. Hard off: DEVKIT_TELEMETRY=0.",
       "default": false,
       "required": false
     }

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Give the `coding-agent` a user story ID from your tracker and it orchestrates th
 **Install in one command:**
 
 ```bash
-npm create @theam/dev-kit
+npm create @theagilemonkeys/dev-kit
 ```
 
 Interactive setup — tracker, Figma, telemetry consent, org — then it installs the plugin for you. Full options in [Installing in Claude Code](#installing-in-claude-code).
@@ -50,7 +50,7 @@ The kit is a Claude Code **plugin**. Install it once per developer; it then load
 ### Install with npm (recommended)
 
 ```bash
-npm create @theam/dev-kit
+npm create @theagilemonkeys/dev-kit
 ```
 
 The wizard picks your issue tracker and whether you use Figma, **shows exactly what anonymous telemetry would be collected and lets you opt in or out**, sets your organisation label, writes `.claude/dev-kit.json`, and runs the plugin install for you. Then authorize your connectors (below) and you're done.
@@ -199,7 +199,7 @@ Adding a tracker, PR host, or design tool is an **adapter**, not a rewrite — s
 
 ## Telemetry (anonymous, opt-in, OFF by default)
 
-The kit can share **anonymous token counts** so the maintainers can show aggregate impact. It is **off by default**; you opt in via the setup wizard (`npm create @theam/dev-kit`). Clients ship **no API key** and never call analytics directly — they POST to a [relay](./packages/telemetry-relay/) that re-enforces a [machine-readable contract](./telemetry/contract.v1.json) and strips your IP before forwarding to PostHog. Events are anonymous (a random `install_id`); never prompts, code, file names, ticket contents, emails, or org-instance data — and only sessions where the kit actually ran. Kill switch: `DEVKIT_TELEMETRY=0`. Runs in the CLI, IDE extensions, and the Desktop app's **Code tab** (needs Node on `PATH`). Full details and the exact payload: **[TELEMETRY.md](./TELEMETRY.md)**.
+The kit can share **anonymous token counts** so the maintainers can show aggregate impact. It is **off by default**; you opt in via the setup wizard (`npm create @theagilemonkeys/dev-kit`). Clients ship **no API key** and never call analytics directly — they POST to a [relay](./packages/telemetry-relay/) that re-enforces a [machine-readable contract](./telemetry/contract.v1.json) and strips your IP before forwarding to PostHog. Events are anonymous (a random `install_id`); never prompts, code, file names, ticket contents, emails, or org-instance data — and only sessions where the kit actually ran. Kill switch: `DEVKIT_TELEMETRY=0`. Runs in the CLI, IDE extensions, and the Desktop app's **Code tab** (needs Node on `PATH`). Full details and the exact payload: **[TELEMETRY.md](./TELEMETRY.md)**.
 
 ## Troubleshooting
 

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -16,7 +16,7 @@ claude-dev-kit can share **anonymous, opt-in** usage telemetry so The Agile Monk
 The easy path is the setup wizard:
 
 ```bash
-npm create @theam/dev-kit
+npm create @theagilemonkeys/dev-kit
 ```
 
 It shows exactly what would be collected and asks yes/no, writing your choice to `~/.claude/dev-kit-telemetry/config.json` (per user). To change your mind, re-run it, or:

--- a/packages/create-dev-kit/README.md
+++ b/packages/create-dev-kit/README.md
@@ -1,9 +1,9 @@
-# @theam/create-dev-kit
+# @theagilemonkeys/create-dev-kit
 
 Interactive setup for the [**claude-dev-kit**](https://github.com/theam/claude-dev-kit) Claude Code plugin — an issue-to-PR workflow with enforced quality gates, for any tech stack.
 
 ```bash
-npm create @theam/dev-kit
+npm create @theagilemonkeys/dev-kit
 ```
 
 Zero dependencies (Node built-ins only), so it's trivial to audit before you run it.

--- a/packages/create-dev-kit/index.mjs
+++ b/packages/create-dev-kit/index.mjs
@@ -3,7 +3,7 @@
  * create-dev-kit — interactive setup for the claude-dev-kit plugin.
  *
  * Zero dependencies (only Node built-ins) so it is trivial to audit before you
- * run it via `npm create @theam/dev-kit`. It writes two files:
+ * run it via `npm create @theagilemonkeys/dev-kit`. It writes two files:
  *   - <repo>/.claude/dev-kit.json           (tracker choice, figma flag, org label)
  *   - ~/.claude/dev-kit-telemetry/config.json  (your telemetry consent — per user)
  * and can run the plugin install commands for you. It never sends anything itself.

--- a/packages/create-dev-kit/package.json
+++ b/packages/create-dev-kit/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@theam/create-dev-kit",
+  "name": "@theagilemonkeys/create-dev-kit",
   "version": "0.1.0",
   "description": "Interactive setup for the claude-dev-kit Claude Code plugin: pick your issue tracker and design tool, review and opt in (or out) of anonymous telemetry, set your organisation, and write the config.",
   "license": "Apache-2.0",

--- a/packages/telemetry-relay/package.json
+++ b/packages/telemetry-relay/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@theam/claude-dev-kit-telemetry-relay",
+  "name": "@theagilemonkeys/claude-dev-kit-telemetry-relay",
   "version": "0.1.0",
   "private": true,
   "type": "module",


### PR DESCRIPTION
The npm org is **`theagilemonkeys`**, not `theam`. Renames the package and all references so the published command actually works.

- `@theam/create-dev-kit` → **`@theagilemonkeys/create-dev-kit`**
- Install command everywhere → **`npm create @theagilemonkeys/dev-kit`** (README ×3, TELEMETRY.md, wizard header + comment, plugin.json userConfig, relay package name)
- Verified: no `@theam/` left anywhere; JSON valid. Plugin version → 0.12.1.

After merge, first publish is: `cd packages/create-dev-kit && npm publish` (already `publishConfig.access: public`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)