### PR TITLE
Fix: duplicate hooks manifest breaks plugin hook load (v0.12.2)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fullstack-dev-kit",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Issue-to-PR workflow kit for any tech stack. Fetch a user story from your tracker (Jira, Linear, GitHub Issues, Azure DevOps) and any linked Figma designs, implement with plan approval, enforce >95% coverage and a security pass, generate e2e tests, open the PR, fix review findings, and move the ticket to review.",
   "license": "Apache-2.0",
   "homepage": "https://github.com/theam/claude-dev-kit",
@@ -21,7 +21,6 @@
     "pull-request",
     "tech-stack-agnostic"
   ],
-  "hooks": "./hooks/hooks.json",
   "userConfig": {
     "telemetry_enabled": {
       "type": "boolean",


### PR DESCRIPTION
**Bug caught by a clean install from the published npm package.** Every install showed, in `claude plugin list`:

```
Error: Hook load failed: Duplicate hooks file detected: ./hooks/hooks.json …
The standard hooks/hooks.json is loaded automatically, so manifest.hooks should
only reference additional hook files.
```

Cause: Claude Code **auto-loads `hooks/hooks.json`** by convention, but `plugin.json` also declared `"hooks": "./hooks/hooks.json"` → double reference → the SessionEnd telemetry hook fails to load on every install.

Fix: remove the `hooks` field. The hook still auto-loads from `hooks/hooks.json`, so telemetry is unaffected.

**Verified:** isolated install from the local repo → `claude plugin list` shows `Status: ✔ enabled`, no hook error. Version → 0.12.2.

> Note: the currently-released v0.12.1 has this error (hook doesn't load; agents/skills/commands still work). After merge, `claude plugin marketplace update claude-dev-kit` picks up 0.12.2 and clears it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)