### PR TITLE
OSS community health files (SECURITY, CoC, CODEOWNERS, templates)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,18 @@
+# Code owners — reviewers auto-requested on matching changes.
+# Replace @theam/maintainers with your real GitHub team or usernames
+# (e.g. @alice @bob). Until it's a valid team/user, GitHub ignores it.
+
+# Default owner for everything
+*                       @theam/maintainers
+
+# The published npm package — supply-chain sensitive, always review.
+/packages/              @theam/maintainers
+
+# Telemetry: client, contract, and relay — privacy sensitive.
+/scripts/telemetry.mjs  @theam/maintainers
+/telemetry/             @theam/maintainers
+/hooks/                 @theam/maintainers
+
+# Plugin manifest + always-on rules.
+/.claude-plugin/        @theam/maintainers
+/instructions/          @theam/maintainers

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,22 @@
+---
+name: Bug report
+about: Something in the kit didn't work as expected
+title: "[bug] "
+labels: bug
+---
+
+**What you ran and where**
+- Command (e.g. `/fullstack-dev-kit:work-story PROJ-1234`):
+- Surface: CLI / VS Code (or JetBrains) extension / Claude Desktop Code tab
+- Kit version (`claude plugin list`):
+- `claude --version`, OS:
+
+**Stack & tracker (if relevant)**
+- Stack (node / python / dotnet / …):
+- Tracker (jira / linear / github / azure) and PR host:
+
+**What happened vs. what you expected**
+Paste the relevant part of the session output (redact anything private).
+
+**Anything else**
+Did you check the [Troubleshooting](../../README.md#troubleshooting) table?

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/theam/claude-dev-kit/security/advisories/new
+    about: Please report security issues privately — do not open a public issue.
+  - name: Question / discussion
+    url: https://github.com/theam/claude-dev-kit/discussions
+    about: For questions and ideas, use Discussions (if enabled).

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,16 @@
+---
+name: Feature request / improvement
+about: Suggest an improvement, a new adapter, or a stack profile
+title: "[feat] "
+labels: enhancement
+---
+
+**What would you like the kit to do?**
+Describe the problem or gap first, then the idea.
+
+**Is this an adapter or stack profile?**
+- New tracker / PR host? → see [CONTRIBUTING](../../CONTRIBUTING.md).
+- New or improved stack profile? → often just one file in `instructions/stacks/`; PRs very welcome.
+
+**Anything else**
+Context, examples, or links.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+<!-- Thanks for contributing! Keep PRs small and single-concern. -->
+
+## What & why
+Briefly, what this changes and the problem it solves.
+
+## Type
+- [ ] Bug fix
+- [ ] New/improved stack profile (`instructions/stacks/…`)
+- [ ] New/improved adapter (tracker / PR host)
+- [ ] Docs
+- [ ] Other:
+
+## Checklist
+- [ ] Keeps the kit **stack-agnostic** (nothing client/company/project-specific; stack detail stays in profiles/consuming repo).
+- [ ] Doesn't weaken the quality gates or the telemetry privacy guarantees.
+- [ ] Docs updated in the same PR (README "What's inside" / affected flow) if behavior changed.
+- [ ] If this touches `packages/` or `telemetry/`, I've flagged it for extra review (supply-chain / privacy sensitive).
+- [ ] Version bumped in `.claude-plugin/plugin.json` if users should receive this (merging without a bump updates nobody).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,63 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best for the overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+**conduct@theagilemonkeys.com**. All complaints will be reviewed and
+investigated promptly and fairly. All community leaders are obligated to respect
+the privacy and security of the reporter of any incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.
+
+[homepage]: https://www.contributor-covenant.org

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,29 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please **do not** open a public issue for security problems.
+
+Report privately, either:
+
+- **GitHub → Security → "Report a vulnerability"** (private vulnerability reporting), or
+- email **security@theagilemonkeys.com**
+
+Include: what you found, how to reproduce it, affected version(s), and the impact you expect. We aim to acknowledge within a few business days and will keep you updated on the fix and disclosure timeline.
+
+## Scope — what matters most here
+
+This kit is a set of Markdown prompts (agents/skills/commands) plus a small, zero-dependency npm setup wizard and an optional telemetry relay. The highest-value areas to look at:
+
+- **Supply chain of `@theagilemonkeys/create-dev-kit`** — anything that could let a malicious version run on users' machines (`npm create` executes it). The package ships only `index.mjs` + `README.md`, has no dependencies, and no install/lifecycle scripts.
+- **Telemetry** — it must remain anonymous and opt-in, and must never transmit prompts, code, paths, ticket content, emails, org-instance data, or the caller IP. See [TELEMETRY.md](./TELEMETRY.md); the relay strips IP and re-enforces [`telemetry/contract.v1.json`](./telemetry/contract.v1.json).
+- **The relay** — it holds the PostHog key only in its own environment; it must never accept payloads that break the contract.
+
+## What is not a vulnerability
+
+- The plugin runs with the user's own permissions inside Claude Code (like any plugin) — that's expected. Report anything that exceeds or abuses that (e.g. exfiltration, hidden network calls).
+- Prompt content or model behavior that is a quality issue rather than a security one — open a normal issue instead.
+
+## Supported versions
+
+The latest released version on `main` is supported. Please reproduce on the latest before reporting.


### PR DESCRIPTION
Pre-open-source hygiene — the files GitHub and contributors expect on a public repo.

- **SECURITY.md** — private vulnerability reporting path + what's in scope (supply chain of the npm package, telemetry privacy, the relay).
- **CODE_OF_CONDUCT.md** — Contributor Covenant 2.1 (contact: `conduct@theagilemonkeys.com` — change if you prefer another).
- **.github/CODEOWNERS** — routes reviews; guards the sensitive paths (`packages/` npm, `telemetry/`, `hooks/`, `.claude-plugin/`, `instructions/`). ⚠️ Replace `@theam/maintainers` with your real GitHub team/usernames.
- **Issue templates** (bug / feature) + **config.yml** (blank issues off, security + discussions links) + **PR template**.

Emails (`security@` / `conduct@theagilemonkeys.com`) are placeholders — adjust to your real inboxes.

Repo settings (branch protection, topics, secret scanning, etc.) are applied separately via `gh` / at the moment of going public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)