### PR TITLE
Add CHANGELOG + release process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,51 @@
+# Changelog
+
+All notable changes to claude-dev-kit are documented here. The format is based on
+[Keep a Changelog](https://keepachangelog.com/); the project follows SemVer.
+
+The `version` in `.claude-plugin/plugin.json` is what reaches installed clients —
+a release is only "live" for users once that is bumped and published.
+
+## [Unreleased]
+
+## [0.12.2] - 2026-07-23
+### Fixed
+- Plugin failed to load its hook (`Duplicate hooks file detected`) on every install — Claude Code auto-loads `hooks/hooks.json`, so the redundant `hooks` field in `plugin.json` was removed. The telemetry hook still auto-loads.
+
+## [0.12.1] - 2026-07-23
+### Fixed
+- Scope the npm package to the real org: `@theam/create-dev-kit` → **`@theagilemonkeys/create-dev-kit`** (install command: `npm create @theagilemonkeys/dev-kit`).
+
+## [0.12.0] - 2026-07-22
+### Changed
+- **Adaptive quality gates** — coverage / unit-test / e2e gates now enforce the *project's own* standard, detected each run; they never impose tests or scaffold a framework on a project that doesn't use one. Optional `gates` config (`auto` (default) / `required` / `off`, plus `coverage.min`). Plan-approval and security passes remain non-adaptive.
+
+## [0.11.0] - 2026-07-22
+### Added
+- Telemetry `entrypoint` property — which Claude Code surface ran the pipeline (CLI, VS Code / JetBrains extension, Claude Desktop Code tab, SDK).
+
+## [0.10.0] - 2026-07-22
+### Added
+- **Angular, React, Vue** stack profiles (the frontend frameworks build on `node`).
+
+## [0.9.0] - 2026-07-22
+### Changed
+- Research-backed enrichment of all stack profiles (accurate, current tooling; precision over length).
+
+## [0.8.0] - 2026-07-22
+### Added
+- **Pluggable PR host** — Bitbucket and GitLab adapters alongside GitHub, configurable via `prHost`.
+
+## [0.7.0] - 2026-07-21
+### Added
+- **Per-stack baseline profiles** (`instructions/stacks/`): node, python, dotnet, java, go, ruby, php, rust — with runtime stack detection and a no-`CLAUDE.md` fallback.
+
+## [0.6.0] - 2026-07-21
+### Added
+- **Relay-based telemetry** (contract + relay; no key in the client, IP stripped) and the **`@theagilemonkeys/create-dev-kit`** interactive setup wizard.
+
+## [0.5.0] - 2026-07-20
+### Added
+- Open-sourced and made **stack-agnostic**; issue-tracker adapters (Jira / Linear / GitHub Issues / Azure DevOps); Apache 2.0 license; anonymous opt-in telemetry (initial version).
+### Removed
+- The Playwright/ffmpeg demo-GIF step (didn't fit a multi-stack, multi-surface kit).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,21 @@ Restart your Claude session and exercise the changed component — for workflow 
 
 ## Releases (maintainers)
 
-Users only receive changes when `version` in `.claude-plugin/plugin.json` is bumped — merging without a bump updates nobody. Release = merge → bump version → push to `main`. See the README's "Releasing" section.
+Users only receive changes when `version` in `.claude-plugin/plugin.json` is **bumped** — merging without a bump updates nobody. There is no loud "update available" notification in Claude Code: with **auto-update** enabled the new version arrives silently at session start, otherwise users run `claude plugin marketplace update claude-dev-kit`. So we drive awareness via **GitHub Releases + CHANGELOG**.
+
+Release checklist:
+
+1. Bump `version` in `.claude-plugin/plugin.json` (SemVer: patch = fix, minor = feature, major = breaking).
+2. Move the `CHANGELOG.md` `[Unreleased]` items under a new `## [X.Y.Z] - <date>` heading.
+3. Merge to `main` (PR).
+4. Tag + publish a GitHub Release (this is what notifies watchers and shows on the repo):
+   ```bash
+   gh release create vX.Y.Z --title "vX.Y.Z" --notes "<summary — mirror the CHANGELOG entry>"
+   ```
+5. For the npm package, if it changed: `cd packages/create-dev-kit && npm version <bump> && npm publish` (see [its notes](packages/create-dev-kit/README.md); the plugin and the wizard version independently).
+6. For internal teams, drop a note in your channel.
+
+Encourage users to enable auto-update (`/plugin` → Marketplaces → `claude-dev-kit`) so a bump + release reaches them automatically.
 
 ## License
 


### PR DESCRIPTION
Sets up how users learn about new versions: a **CHANGELOG.md** (0.5.0 → 0.12.2) and an expanded **Releases** checklist in CONTRIBUTING (bump → changelog → merge → tag + `gh release`). Claude Code has no loud 'update available' notice — auto-update pulls silently, so GitHub Releases + CHANGELOG are the awareness channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)