### PR TITLE
Wire telemetry to the live relay (v0.12.3)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fullstack-dev-kit",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "Issue-to-PR workflow kit for any tech stack. Fetch a user story from your tracker (Jira, Linear, GitHub Issues, Azure DevOps) and any linked Figma designs, implement with plan approval, enforce >95% coverage and a security pass, generate e2e tests, open the PR, fix review findings, and move the ticket to review.",
   "license": "Apache-2.0",
   "homepage": "https://github.com/theam/claude-dev-kit",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ a release is only "live" for users once that is bumped and published.
 
 ## [Unreleased]
 
+## [0.12.3] - 2026-07-27
+### Changed
+- Point `default_relay_url` at the live telemetry relay (`https://claude-dev-kit-telemetry-relay.vercel.app`). With this, opted-in clients actually reach the relay → PostHog. Verified end to end (relay returns `202 accepted`, contract enforced, IP discarded in PostHog).
+
 ## [0.12.2] - 2026-07-23
 ### Fixed
 - Plugin failed to load its hook (`Duplicate hooks file detected`) on every install — Claude Code auto-loads `hooks/hooks.json`, so the redundant `hooks` field in `plugin.json` was removed. The telemetry hook still auto-loads.

--- a/packages/telemetry-relay/contract.v1.json
+++ b/packages/telemetry-relay/contract.v1.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "event_name": "kit_session_completed",
-  "default_relay_url": "https://claude-dev-kit-telemetry.vercel.app",
+  "default_relay_url": "https://claude-dev-kit-telemetry-relay.vercel.app",
   "duration_buckets": ["lt_1m", "1m_to_5m", "5m_to_15m", "15m_to_1h", "gte_1h"],
   "allowed_properties": {
     "schema_version": { "type": "integer", "const": 1 },

--- a/telemetry/contract.v1.json
+++ b/telemetry/contract.v1.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "event_name": "kit_session_completed",
-  "default_relay_url": "https://claude-dev-kit-telemetry.vercel.app",
+  "default_relay_url": "https://claude-dev-kit-telemetry-relay.vercel.app",
   "duration_buckets": ["lt_1m", "1m_to_5m", "5m_to_15m", "15m_to_1h", "gte_1h"],
   "allowed_properties": {
     "schema_version": { "type": "integer", "const": 1 },


### PR DESCRIPTION
The telemetry relay is **deployed and verified**:

- `GET /api/ingest` → 405 (alive)
- `POST /api/ingest` → **202 `{"accepted":true\}`** (key configured, forwarded to PostHog; contract drops unknown fields; PostHog IP capture disabled)

This points `default_relay_url` (both contract copies) at the real deployment `https://claude-dev-kit-telemetry-relay.vercel.app` (was a placeholder). With this merged + released, **opted-in clients start sending for real**. Version → 0.12.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)