### PR TITLE
Set CODEOWNERS (@atamanvega) + security/conduct contact email

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,18 +1,17 @@
 # Code owners — reviewers auto-requested on matching changes.
-# Replace @theam/maintainers with your real GitHub team or usernames
-# (e.g. @alice @bob). Until it's a valid team/user, GitHub ignores it.
+# Currently @atamanvega only; add more maintainers / a team here as they join.
 
 # Default owner for everything
-*                       @theam/maintainers
+*                       @atamanvega
 
 # The published npm package — supply-chain sensitive, always review.
-/packages/              @theam/maintainers
+/packages/              @atamanvega
 
 # Telemetry: client, contract, and relay — privacy sensitive.
-/scripts/telemetry.mjs  @theam/maintainers
-/telemetry/             @theam/maintainers
-/hooks/                 @theam/maintainers
+/scripts/telemetry.mjs  @atamanvega
+/telemetry/             @atamanvega
+/hooks/                 @atamanvega
 
 # Plugin manifest + always-on rules.
-/.claude-plugin/        @theam/maintainers
-/instructions/          @theam/maintainers
+/.claude-plugin/        @atamanvega
+/instructions/          @atamanvega

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -50,7 +50,7 @@ an individual is officially representing the community in public spaces.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-**conduct@theagilemonkeys.com**. All complaints will be reviewed and
+**ataman@theagilemonkeys.com**. All complaints will be reviewed and
 investigated promptly and fairly. All community leaders are obligated to respect
 the privacy and security of the reporter of any incident.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,7 +7,7 @@ Please **do not** open a public issue for security problems.
 Report privately, either:
 
 - **GitHub → Security → "Report a vulnerability"** (private vulnerability reporting), or
-- email **security@theagilemonkeys.com**
+- email **ataman@theagilemonkeys.com**
 
 Include: what you found, how to reproduce it, affected version(s), and the impact you expect. We aim to acknowledge within a few business days and will keep you updated on the fix and disclosure timeline.
 


### PR DESCRIPTION
Fills the two pre-open placeholders: `CODEOWNERS` now points to **@atamanvega** (add more maintainers/a team later), and SECURITY.md / CODE_OF_CONDUCT.md contact is **ataman@theagilemonkeys.com** for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)