### PR TITLE
Telemetry: dedup, faster flush, user-level org, suppress GeoIP (v0.14.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fullstack-dev-kit",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Issue-to-PR workflow kit for any tech stack. Fetch a user story from your tracker (Jira, Linear, GitHub Issues, Azure DevOps) and any linked Figma designs, implement with plan approval, enforce >95% coverage and a security pass, generate e2e tests, open the PR, fix review findings, and move the ticket to review.",
   "license": "Apache-2.0",
   "homepage": "https://github.com/theam/claude-dev-kit",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ a release is only "live" for users once that is bumped and published.
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-07-28
+### Changed
+- Outbox stale threshold 30 min → **10 min**, so sessions that never fire `SessionEnd` (e.g. Claude Desktop "new chat" doesn't) are flushed sooner on the next session start.
+### Added
+- **Per-session dedup**: the client sends a stable random `event_uuid` per session (not the real session id); the relay forwards it as the PostHog event `uuid` so re-sends of one session count once.
+- **Org attribution falls back to the user level**: `org` is read from the repo's `.claude/dev-kit.json` first, then from `~/.claude/dev-kit-telemetry/config.json`. The wizard now stores `org` there too — so attribution works in worktrees and repos without a committed `telemetry.org`.
+### Fixed
+- Relay sets `$geoip_disable` on forwarded events. PostHog was geolocating the **relay's** IP (not the user's — the user's IP never reaches PostHog), which was noise; now suppressed.
+
+*(Relay redeploys with this release — `packages/telemetry-relay` changed. Client changes reach users via the plugin version bump.)*
+
 ## [0.13.0] - 2026-07-27
 ### Changed
 - Telemetry delivery is now robust to sessions that never close cleanly (crash or a session left open forever). Added an **outbox**: a `Stop` hook writes a cheap per-session marker (no transcript parse, no network) and `SessionStart` flushes stale markers from prior sessions; `SessionEnd` still sends immediately. Still one anonymous event per session, opt-in only; state in `~/.claude/dev-kit-telemetry/pending.json`, self-cleaning. No relay changes.

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -85,6 +85,8 @@ By default events carry only a random `install_id`. An organisation that wants i
 
 When present it is sent as `org` (and a PostHog `company` group). Off unless you add it.
 
+You can also set it **once at the user level** — the setup wizard stores your `org` in `~/.claude/dev-kit-telemetry/config.json`, which is used as a fallback when a repo (or a git worktree) has no `telemetry.org`. The repo value always wins if both are set.
+
 Why this is GDPR-safe done this way:
 
 - **It identifies a company, not a person.** GDPR protects natural persons; an organisation label is not personal data on its own.

--- a/packages/create-dev-kit/index.mjs
+++ b/packages/create-dev-kit/index.mjs
@@ -119,6 +119,9 @@ async function main() {
     schema_version: 1,
     consent: consent ? 'granted' : 'denied',
     install_id: installId,
+    // Also store org at the user level so attribution works in every repo/worktree,
+    // not only where a committed .claude/dev-kit.json carries telemetry.org.
+    ...(org.trim() ? { org: org.trim().slice(0, 64) } : {}),
   });
 
   // --- Report + offer to install ------------------------------------------

--- a/packages/telemetry-relay/api/ingest.js
+++ b/packages/telemetry-relay/api/ingest.js
@@ -73,8 +73,14 @@ export default async function handler(req, res) {
 
   const properties = sanitize(body.properties);
   properties.$process_person_profile = false; // anonymous: no PostHog person profile
+  properties.$geoip_disable = true;           // don't derive geolocation (the IP PostHog sees is this relay's, not the user's)
   const org = typeof body.org === 'string' && body.org.trim() ? body.org.trim().slice(0, 64) : undefined;
   if (org) properties.org = org;
+
+  // Per-session dedup id from the client (random, not the real session id) → PostHog
+  // deduplicates events sharing this uuid, so re-sends of one session count once.
+  const eventUuid = typeof body.event_uuid === 'string' && /^[0-9a-fA-F-]{8,64}$/.test(body.event_uuid)
+    ? body.event_uuid : undefined;
 
   const phEvent = {
     api_key: POSTHOG_API_KEY,
@@ -82,6 +88,7 @@ export default async function handler(req, res) {
     distinct_id: installId,
     // NOTE: the caller IP is never read, forwarded, or stored by this relay.
     properties,
+    ...(eventUuid ? { uuid: eventUuid } : {}),
     ...(org ? { $groups: { company: org } } : {}),
   };
 

--- a/scripts/telemetry.mjs
+++ b/scripts/telemetry.mjs
@@ -31,7 +31,7 @@ const done = () => process.exit(0); // fail-silent, always
 const STATE_DIR = join(homedir(), '.claude', 'dev-kit-telemetry');
 const CONFIG = join(STATE_DIR, 'config.json');
 const PENDING = join(STATE_DIR, 'pending.json');
-const STALE_MS = 30 * 60 * 1000;             // marker not refreshed in 30 min → its session ended without SessionEnd
+const STALE_MS = 10 * 60 * 1000;             // marker unrefreshed for 10 min → session is done → safe to flush on next start
 const MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;  // hard cap: never keep a marker longer than this
 
 const KIT_MARKERS = [
@@ -93,7 +93,7 @@ try {
 
   // Compute one session's event from its transcript and POST it. Content is
   // never inspected beyond summing `usage` and checking a kit component ran.
-  async function flush(transcriptPath, cwd, ep, ccVersion) {
+  async function flush(transcriptPath, cwd, ep, ccVersion, dedup) {
     if (!transcriptPath || !existsSync(transcriptPath)) return;
     const lines = readFileSync(transcriptPath, 'utf8').split('\n').filter(Boolean);
     if (!lines.some((l) => KIT_MARKERS.some((m) => l.includes(m)))) return; // kit didn't run this session
@@ -126,12 +126,17 @@ try {
       const o = c?.telemetry?.org;
       if (typeof o === 'string' && o.trim()) org = o.trim().slice(0, 64);
     } catch { /* ignore */ }
+    // Fallback to the user-level org (set once in the wizard). Robust to worktrees
+    // and repos whose committed dev-kit.json lacks a telemetry.org block.
+    if (!org && typeof cfg.org === 'string' && cfg.org.trim()) org = cfg.org.trim().slice(0, 64);
 
     const payload = {
       schema_version: 1,
       event_name: 'kit_session_completed',
       install_id: installId,
       org,
+      event_uuid: dedup, // per-session id (random, NOT the real session id) so the relay/PostHog can dedup re-sends
+
       properties: {
         schema_version: 1,
         kit_version: kitVersion,
@@ -165,6 +170,7 @@ try {
         cwd: event.cwd || process.cwd(),
         entrypoint,
         cc_version: event.version,
+        dedup: pend[sessionId]?.dedup || randomUUID(), // stable per session → one event even across re-sends
         updated: Date.now(),
       };
       writeJsonAtomic(PENDING, pend);
@@ -173,8 +179,9 @@ try {
   }
 
   if (evName === 'SessionEnd') {
-    await flush(event.transcript_path, event.cwd || process.cwd(), entrypoint, event.version);
     const pend = readJson(PENDING, {});
+    const dedup = pend[sessionId]?.dedup || randomUUID();
+    await flush(event.transcript_path, event.cwd || process.cwd(), entrypoint, event.version, dedup);
     if (sessionId && pend[sessionId]) { delete pend[sessionId]; writeJsonAtomic(PENDING, pend); }
     done();
   }
@@ -189,7 +196,7 @@ try {
       const age = now - (m?.updated || 0);
       if (age > MAX_AGE_MS) { delete pend[sid]; changed = true; continue; }
       if (age > STALE_MS) {                                  // abandoned session → send its event
-        await flush(m.transcript_path, m.cwd, m.entrypoint, m.cc_version);
+        await flush(m.transcript_path, m.cwd, m.entrypoint, m.cc_version, m.dedup || randomUUID());
         delete pend[sid]; changed = true;
       }
     }
@@ -198,7 +205,7 @@ try {
   }
 
   // Fallback (unknown/absent event name): behave like SessionEnd — best-effort single send.
-  await flush(event.transcript_path, event.cwd || process.cwd(), entrypoint, event.version);
+  await flush(event.transcript_path, event.cwd || process.cwd(), entrypoint, event.version, randomUUID());
 } catch {
   /* fail-silent: telemetry must never disrupt a session */
 }


### PR DESCRIPTION
Follow-ups from the first real test:

- **Faster delivery on Desktop** — Claude Desktop's *new chat* doesn't fire `SessionEnd`, so the outbox stale threshold drops **30 → 10 min** (flushed on the next session start).
- **Dedup** — client sends a stable random `event_uuid` per session (not the real session id); the relay forwards it as the PostHog event `uuid` so re-sends count once. (The duplicate events you saw were manual debug re-sends; this prevents accidental doubles.)
- **Org attribution now works in worktrees** — `org` falls back to the user-level config (`~/.claude/dev-kit-telemetry/config.json`), and the wizard stores it there. Root cause of "no org": the session ran in a worktree whose `dev-kit.json` lacked `telemetry.org` (only the main repo had it). Repo value still wins.
- **Suppress GeoIP** — the relay sets `$geoip_disable`. PostHog was geolocating the **relay's** IP (Ashburn/Vercel), never the user's (the user IP never reaches PostHog); this removes the noise.

**Relay redeploys** with this (touches `packages/telemetry-relay`). Verified end to end. Version → 0.14.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)