### PR TITLE
Trigger relay redeploy (bump telemetry-relay to 0.1.1)

### DIFF
--- a/packages/telemetry-relay/package.json
+++ b/packages/telemetry-relay/package.json
@@ -1,9 +1,11 @@
 {
   "name": "@theagilemonkeys/claude-dev-kit-telemetry-relay",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "description": "Telemetry relay for claude-dev-kit: re-enforces the contract, strips caller IP, forwards anonymous events to PostHog. Deploy on Vercel.",
   "license": "Apache-2.0",
-  "engines": { "node": ">=18" }
+  "engines": {
+    "node": ">=18"
+  }
 }


### PR DESCRIPTION
Fresh commit to `packages/telemetry-relay` so Vercel's Git integration creates a new deployment (the previous one failed the author check and can't be redeployed from the UI).

**Merge this only AFTER** authorizing the git author (`atamanvega`) in the Vercel team, so this deployment passes and the v0.14.0 relay (`$geoip_disable` + dedup `uuid`) goes live. If the author check still blocks it, fall back to `vercel deploy --prod` from `packages/telemetry-relay` as `ataman-6045`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)