### PR TITLE
Drop internal product/repo names from public docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ a release is only "live" for users once that is bumped and published.
 
 ## [0.15.0] - 2026-07-28
 ### Added
-- **PR review loop** improvements (adapted from `theam/monkey-skills` · `tam-pr-review-loop`):
+- **PR review loop** improvements (adapted from an internal The Agile Monkeys review tool):
   - **PR intent statement** as the scope ruler in `pr-review` and `fix-pr` — a defect inside the intent blocks; a valid concern outside it is a follow-up, not PR expansion.
   - `fix-pr` now builds a **ledger** (one row per distinct claim, deduped across CI / reviewers / bots / self-review) with one verdict each: **FIX_NOW / DEFER_TO_ISSUE / DISCARD**.
   - **DEFER_TO_ISSUE** files a tracked issue via the configured tracker adapter instead of losing out-of-scope findings.

--- a/scripts/watch-pr-feedback.sh
+++ b/scripts/watch-pr-feedback.sh
@@ -9,7 +9,7 @@
 # GitHub only (uses `gh`). For Bitbucket/GitLab, fix-pr falls back to a single
 # post-push check via that host's API instead of this watcher.
 #
-# Adapted from theam/monkey-skills (tam-pr-review-loop). Apache-2.0.
+# Adapted from an internal The Agile Monkeys review tool. Apache-2.0.
 #
 # Usage:   watch-pr-feedback.sh <pr-number>
 #


### PR DESCRIPTION
The PR-review-loop attribution named a **private** repo and internal product names (`tam-*`) in the public repo — that neither resolves for external users nor should be exposed. Replaced with a neutral "internal The Agile Monkeys review tool" attribution in `scripts/watch-pr-feedback.sh` and `CHANGELOG.md`. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)