### PR TITLE
Fold adversarial + delivery-readiness facets into pr-review/create-pr (v0.16.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fullstack-dev-kit",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Issue-to-PR workflow kit for any tech stack. Fetch a user story from your tracker (Jira, Linear, GitHub Issues, Azure DevOps) and any linked Figma designs, implement with plan approval, enforce >95% coverage and a security pass, generate e2e tests, open the PR, fix review findings, and move the ticket to review.",
   "license": "Apache-2.0",
   "homepage": "https://github.com/theam/claude-dev-kit",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ a release is only "live" for users once that is bumped and published.
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-07-28
+### Added
+- `pr-review`: an **optional, proportional adversarial check** for high-stakes diffs only (auth, money, personal data, migrations, concurrency, hard-to-roll-back) — a targeted skeptical second look, never a mandatory re-review of routine changes.
+- `create-pr`: an **optional "Delivery readiness"** section (rollback, migrations, config/secrets, docs, breaking change) — included only when it applies, skipped for trivial changes.
+
+Folded in as lightweight facets of existing skills — no new agents, no extra passes by default — to keep token cost down.
+
 ## [0.15.0] - 2026-07-28
 ### Added
 - **PR review loop** improvements (adapted from `theam/monkey-skills` · `tam-pr-review-loop`):

--- a/skills/create-pr/SKILL.md
+++ b/skills/create-pr/SKILL.md
@@ -49,13 +49,21 @@ decisions taken, plain language — same content as the tracker comment>
 
 ### How it was verified
 - Unit tests: <command + result>
-- Coverage on touched files: <summary, all ≥ 95%>
+- Coverage on touched files: <summary — meets the project's bar>
 - E2E: <suites run + result>
 - Security pass: <verdict>
 - Lint: clean
 
 ### Notes for reviewers
 - <risks, follow-ups, technical decisions>
+
+### Delivery readiness
+<Include only the lines that apply — skip this whole section for trivial/internal changes; don't pad.>
+- Rollback: safe to revert this PR on its own? Flag anything that isn't.
+- Migrations: reversible and safe on a live DB (no long locks; backfill plan)?
+- Config/secrets: new keys have safe defaults; nothing required-but-undocumented.
+- Docs/contract: user-facing or API changes reflected in the docs.
+- Breaking change / behind a feature flag: called out explicitly.
 
 Issue: <link to the tracker item>
 

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -25,6 +25,10 @@ Produce a high-signal review: findings a reviewer would act on, classified and o
 7. **Duplication introduced by this PR** (blocking): new code reimplementing logic already in the repo, or copy-paste between the files this PR adds — fix by reusing/extracting once. *Not* this: two blocks that merely look alike and are about to diverge; pre-existing duplication is a follow-up at most.
 8. **Maintainability**: only issues that materially affect future changes — no style nitpicks a formatter or linter should catch.
 
+## Adversarial check (proportional — do not double every review)
+
+For **high-stakes diffs only** (auth/authorization, money, personal data, migrations, concurrency, anything hard to roll back), before the verdict take one targeted skeptical pass: pick the 1–2 conclusions most likely to be wrong and the 1–2 "looks fine" spots most likely to hide a defect, and actively try to break them (an edge input, a failure/timeout path, a race, a partial write). Routine or low-risk diffs get the normal single pass — this is a focused second look where being wrong is expensive, not a mandatory re-review.
+
 ## Output format
 
 ```


### PR DESCRIPTION
Follows the lightweight recommendation: rather than add whole new agents (adversarial-review, delivery-readiness) — which would add sub-agents, passes, and **token cost to every run** — fold their best facets into the skills we already have. **No new agents, no extra passes by default.**

- **`pr-review` → optional adversarial check**, *proportional*: only for high-stakes diffs (auth, money, personal data, migrations, concurrency, hard-to-roll-back), take one targeted skeptical pass at the 1–2 riskiest conclusions / "looks fine" spots. Routine diffs keep the single pass — explicitly **not** a mandatory re-review.
- **`create-pr` → optional "Delivery readiness"** section (rollback, migration safety, config/secrets defaults, docs/contract, breaking change) — included **only when it applies**, skipped for trivial changes.

Both are short, conditional additions (the text itself is the only per-run cost, and it's small). Keeps the pipeline lean, which is the point.

Independent of #24 (different files/lines). Version → 0.16.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)