### PR TITLE
fix(telemetry): stop duplicate events from concurrent outbox flushes (v0.16.1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fullstack-dev-kit",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Issue-to-PR workflow kit for any tech stack. Fetch a user story from your tracker (Jira, Linear, GitHub Issues, Azure DevOps) and any linked Figma designs, implement with plan approval, enforce >95% coverage and a security pass, generate e2e tests, open the PR, fix review findings, and move the ticket to review.",
   "license": "Apache-2.0",
   "homepage": "https://github.com/theam/claude-dev-kit",

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .DS_Store
 node_modules/
 .vercel/
+.vercel
+.env*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ a release is only "live" for users once that is bumped and published.
 
 ## [Unreleased]
 
+## [0.16.1] - 2026-07-28
+### Fixed
+- **Telemetry duplicate events**: a session could be reported twice (seen when Claude Desktop fires `SessionStart` more than once on reopen). Two causes, both closed:
+  - The outbox flush deleted a marker only *after* the network send, so concurrent hook runs could both flush the same marker. Sends are now guarded by an **at-most-once claim** (an exclusive `sent-<id>` sentinel in `~/.claude/dev-kit-telemetry/`, GC'd past the marker hard-cap) — only the first caller sends.
+  - The per-session dedup id fell back to a fresh random value independently on each code path, so re-sends of one session could carry *different* ids and never dedup. It is now **derived deterministically** from `install_id + session_id` (hashed locally — the real session id never leaves the machine), so every path produces the same id and PostHog collapses re-sends.
+- Client-only change; no relay redeploy needed.
+
 ## [0.16.0] - 2026-07-28
 ### Added
 - `pr-review`: an **optional, proportional adversarial check** for high-stakes diffs only (auth, money, personal data, migrations, concurrency, hard-to-roll-back) — a targeted skeptical second look, never a mandatory re-review of routine changes.

--- a/scripts/telemetry.mjs
+++ b/scripts/telemetry.mjs
@@ -21,10 +21,10 @@
  * Opt out any time: DEVKIT_TELEMETRY=0, or set consent to "denied" in the config.
  * See TELEMETRY.md.
  */
-import { readFileSync, existsSync, writeFileSync, mkdirSync, renameSync } from 'node:fs';
+import { readFileSync, existsSync, writeFileSync, mkdirSync, renameSync, rmSync, readdirSync, statSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join, dirname } from 'node:path';
-import { randomUUID } from 'node:crypto';
+import { randomUUID, createHash } from 'node:crypto';
 
 const done = () => process.exit(0); // fail-silent, always
 
@@ -73,6 +73,26 @@ try {
     installId = randomUUID();
     writeJsonAtomic(CONFIG, { ...cfg, consent: 'granted', install_id: installId });
   }
+
+  // Deterministic per-session dedup id: the SAME value on every code path (Stop /
+  // SessionEnd / SessionStart flush / fallback), so re-sends of one session share
+  // a uuid and PostHog collapses them. Derived locally from install+session — the
+  // real session id never leaves the machine. No session id → random (nothing to
+  // dedup against).
+  const sessionDedup = (sid) => {
+    if (!sid) return randomUUID();
+    const h = createHash('sha256').update(`${installId}|${sid}`).digest('hex');
+    return `${h.slice(0, 8)}-${h.slice(8, 12)}-${h.slice(12, 16)}-${h.slice(16, 20)}-${h.slice(20, 32)}`;
+  };
+
+  // At-most-once claim: exclusively create a sentinel for this dedup id. Only the
+  // first caller wins (O_EXCL), so concurrent hook runs — e.g. Desktop restoring
+  // several sessions at once on reopen — never double-send the same marker. This
+  // is a local guarantee, independent of PostHog's own dedup.
+  const claim = (dedup) => {
+    try { writeFileSync(join(STATE_DIR, `sent-${dedup}`), '', { flag: 'wx' }); return true; }
+    catch { return false; }
+  };
 
   // Relay endpoint (no PostHog key in the client).
   let defaultRelay = 'https://claude-dev-kit-telemetry-relay.vercel.app';
@@ -170,7 +190,7 @@ try {
         cwd: event.cwd || process.cwd(),
         entrypoint,
         cc_version: event.version,
-        dedup: pend[sessionId]?.dedup || randomUUID(), // stable per session → one event even across re-sends
+        dedup: pend[sessionId]?.dedup || sessionDedup(sessionId), // stable per session → one event even across re-sends
         updated: Date.now(),
       };
       writeJsonAtomic(PENDING, pend);
@@ -180,8 +200,10 @@ try {
 
   if (evName === 'SessionEnd') {
     const pend = readJson(PENDING, {});
-    const dedup = pend[sessionId]?.dedup || randomUUID();
-    await flush(event.transcript_path, event.cwd || process.cwd(), entrypoint, event.version, dedup);
+    const dedup = pend[sessionId]?.dedup || sessionDedup(sessionId);
+    if (claim(dedup)) {
+      await flush(event.transcript_path, event.cwd || process.cwd(), entrypoint, event.version, dedup);
+    }
     if (sessionId && pend[sessionId]) { delete pend[sessionId]; writeJsonAtomic(PENDING, pend); }
     done();
   }
@@ -196,16 +218,33 @@ try {
       const age = now - (m?.updated || 0);
       if (age > MAX_AGE_MS) { delete pend[sid]; changed = true; continue; }
       if (age > STALE_MS) {                                  // abandoned session → send its event
-        await flush(m.transcript_path, m.cwd, m.entrypoint, m.cc_version, m.dedup || randomUUID());
+        const dedup = m.dedup || sessionDedup(sid);
+        if (claim(dedup)) {
+          await flush(m.transcript_path, m.cwd, m.entrypoint, m.cc_version, dedup);
+        }
         delete pend[sid]; changed = true;
       }
     }
     if (changed) writeJsonAtomic(PENDING, pend);
+    // GC at-most-once sentinels so they never accumulate past the marker hard-cap.
+    try {
+      for (const f of readdirSync(STATE_DIR)) {
+        if (!f.startsWith('sent-')) continue;
+        try {
+          if (now - statSync(join(STATE_DIR, f)).mtimeMs > MAX_AGE_MS) rmSync(join(STATE_DIR, f), { force: true });
+        } catch { /* ignore one bad entry */ }
+      }
+    } catch { /* ignore */ }
     done();
   }
 
   // Fallback (unknown/absent event name): behave like SessionEnd — best-effort single send.
-  await flush(event.transcript_path, event.cwd || process.cwd(), entrypoint, event.version, randomUUID());
+  {
+    const dedup = sessionDedup(sessionId);
+    if (claim(dedup)) {
+      await flush(event.transcript_path, event.cwd || process.cwd(), entrypoint, event.version, dedup);
+    }
+  }
 } catch {
   /* fail-silent: telemetry must never disrupt a session */
 }


### PR DESCRIPTION
## Problem

A single session could be reported to PostHog **more than once** (observed when Claude Desktop fires `SessionStart` several times on reopen). Two independent causes:

1. **Non-atomic flush.** The stale-marker flush deleted its marker only *after* the network send, so concurrent hook runs both read the marker and both POSTed.
2. **Divergent dedup id.** The per-session dedup id fell back to a fresh `randomUUID()` independently on each code path (`Stop` / `SessionEnd` / `SessionStart` / fallback), so re-sends of one session could carry *different* ids and never dedup at PostHog.

## Fix

- **At-most-once claim:** before any send, exclusively create a `sent-<id>` sentinel (`O_EXCL`) in `~/.claude/dev-kit-telemetry/`. Only the first caller sends; GC'd past the marker hard-cap. Local guarantee, independent of PostHog.
- **Deterministic dedup id:** derived from `install_id + session_id` (hashed locally — the real session id never leaves the machine), so every path yields the same id and PostHog collapses any re-send.

Defense in depth: even if a POST slips through, it carries the same uuid.

## Verification

Isolated integration tests against a local counting relay:
- 2× concurrent `SessionStart` on the same stale marker → **1 POST** ✅
- `SessionEnd` (no marker) and fallback path for the same session → **identical uuid** ✅

## Scope

Client-only (`scripts/telemetry.mjs`); **no relay redeploy needed**. Version bumped to `0.16.1`; CHANGELOG updated. Also gitignores `.vercel`/`.env*` (Vercel CLI artifacts) for pre-public hygiene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)