### PR TITLE
feat(codex): dual-emit portable Agent Plugins 1.0.0 manifest (multi-client) (v0.19.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fullstack-dev-kit",
-  "version": "0.18.1",
+  "version": "0.19.0",
   "description": "Issue-to-PR workflow kit for any tech stack. Fetch a user story from your tracker (Jira, Linear, GitHub Issues, Azure DevOps) and any linked Figma designs, implement with plan approval, enforce >95% coverage and a security pass, generate e2e tests, open the PR, fix review findings, and move the ticket to review.",
   "license": "Apache-2.0",
   "homepage": "https://github.com/theam/claude-dev-kit",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ a release is only "live" for users once that is bumped and published.
   - **Verified against real `codex-cli 0.147`:** Codex *requires* `.codex-plugin/plugin.json` (a portable-only layout errors `missing plugin.json`), and installs cleanly with **both** manifests present — confirming dual-emit is the correct approach.
   - Validator extended: checks the portable manifest (`$schema` const, `name` pattern, closed-schema fields) and Agent Skills naming (hyphen-only skill dirs, frontmatter `name` matches the dir).
   - Portable `mcp.json` intentionally omitted — the 1.0.0 MCP schema has no OAuth field and our trackers use Codex curated connectors; portable clients handle connector auth themselves.
+- **Portable `work-story` orchestration skill.** The end-to-end "ticket → PR" flow now travels to hosts without an orchestrator subagent (Codex, and other Agent-Plugins clients): a `work-story` skill carries the full pipeline (fetch → plan+approval → implement → adaptive gates + security → self-review → PR → update ticket) as a playbook the **host agent runs itself**. Shipped in the plugin bundle only (via `codex/skills/`), **not** in the Claude Code plugin — Claude Code keeps its richer `/work-story` command + `coding-agent` subagent (context isolation, two-phase plan gate) unchanged. Nothing is removed from Claude Code; this is purely additive for the other clients.
 
 ## [0.18.1] - 2026-08-10
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ a release is only "live" for users once that is bumped and published.
 
 ## [Unreleased]
 
+## [0.19.0] - 2026-08-10
+### Added
+- **Portable Agent Plugins 1.0.0 manifest (multi-client).** `build-codex-plugin.mjs` now **dual-emits** a root `plugins/fullstack-dev-kit/plugin.json` following the open [Agent Plugins 1.0.0](https://agent-plugins.org) standard (OpenAI · AWS · Cursor · GitHub · Microsoft · Vercel), alongside the Codex-native `.codex-plugin/plugin.json`. Generated from one source; the `interface` metadata rides under the `com.theagilemonkeys.dev-kit` extensions namespace; `skills/` is shared. The same plugin is now loadable by other Agent-Plugins-compatible clients (Cursor, VS Code, Copilot, …), not just Codex.
+  - **Verified against real `codex-cli 0.147`:** Codex *requires* `.codex-plugin/plugin.json` (a portable-only layout errors `missing plugin.json`), and installs cleanly with **both** manifests present — confirming dual-emit is the correct approach.
+  - Validator extended: checks the portable manifest (`$schema` const, `name` pattern, closed-schema fields) and Agent Skills naming (hyphen-only skill dirs, frontmatter `name` matches the dir).
+  - Portable `mcp.json` intentionally omitted — the 1.0.0 MCP schema has no OAuth field and our trackers use Codex curated connectors; portable clients handle connector auth themselves.
+
 ## [0.18.1] - 2026-08-10
 ### Changed
 - **Codex plugin packaging hardening** (Phase 1 of aligning with the new open *Agent Plugins* standard):

--- a/README.md
+++ b/README.md
@@ -202,27 +202,51 @@ Full **`/work-story <TICKET>`** flow is ticket-first (it fetches the story and m
 
 Either way, a skipped gate is **reported, never hidden**.
 
-## Also runs on Codex (experimental)
+## Also runs on Codex, Cursor & Copilot (experimental)
 
-The kit also targets **OpenAI Codex** (CLI + desktop app) as a **native Codex plugin**.
-Codex has its own plugin system parallel to Claude Code's, so this repo doubles as a
-Codex marketplace ([`.agents/plugins/marketplace.json`](./.agents/plugins/marketplace.json)
-+ [`plugins/fullstack-dev-kit/`](./plugins/fullstack-dev-kit/), whose skills are
-generated from the canonical top-level `skills/`). Install:
+Beyond Claude Code, the kit ships as a plugin for **any [Agent Plugins 1.0.0](https://agent-plugins.org)
+client**. This repo doubles as the plugin: a Codex marketplace
+([`.agents/plugins/marketplace.json`](./.agents/plugins/marketplace.json)) plus a portable
+plugin at [`plugins/fullstack-dev-kit/`](./plugins/fullstack-dev-kit/) that carries **both** a
+Codex-native `.codex-plugin/plugin.json` **and** a portable root `plugin.json`. The same
+`skills/` (generated from the canonical top-level `skills/`) serve every client.
 
+**What travels:** the skills, including a portable **`work-story`** orchestration playbook the
+host agent runs end to end (fetch → plan → implement → gates → review → PR → ticket). **What
+doesn't:** Claude Code's `coding-agent` subagent and curated Codex connectors are host-specific;
+each client uses its own agent + its own MCP/connector auth.
+
+> **Telemetry note:** the anonymous usage sweep is set up **only by the `npm create` wizard**
+> (Codex). A plain plugin install — and any install on Cursor/Copilot — carries **no
+> telemetry**. If you want usage attributed, install via the wizard.
+
+### OpenAI Codex (validated on codex-cli 0.147)
 ```bash
 codex plugin marketplace add theam/claude-dev-kit
 codex plugin add fullstack-dev-kit@claude-dev-kit
 ```
+Then invoke `$work-story PROJ-1234` (or any single skill like `$pr-review`). The `npm create`
+wizard also installs the **connector your tracker implies** (Jira → `atlassian-rovo`, Linear →
+`linear`, Figma → `figma`; GitHub/Azure use their CLIs) and schedules the telemetry sweep.
+Details: [`codex/README.md`](./codex/README.md).
 
-The setup wizard does this for whichever of Claude Code / Codex it finds, installs the
-**Codex connector your tracker choice implies** (Jira → `atlassian-rovo`, Linear → `linear`,
-Figma → `figma`, all curated with native OAuth; GitHub/Azure use their CLIs), and schedules
-an anonymous **telemetry sweep** so Codex sessions
-report usage tagged `agent: codex` (surface `cli` / `vscode`). *Validated against real
-Codex 0.147: marketplace add, plugin install, and the telemetry parser/sweep. In-app
-skill invocation and MCP auth are yours to confirm.* Details:
-[`codex/README.md`](./codex/README.md).
+### GitHub Copilot (VS Code) — *experimental in VS Code*
+Command Palette → **“Chat: Install Plugin From Source”** → paste `https://github.com/theam/claude-dev-kit`.
+VS Code clones and installs it; skills load from the plugin's `skills/` and any `mcp.json` starts
+automatically. Add your tracker's MCP via **MCP: Add Server** (or `.vscode/mcp.json`). *Feature is
+labeled Experimental — behavior may shift.*
+
+### Cursor — *no git-URL installer yet*
+Cursor has no “install from git URL” command today. Either:
+- clone into the local plugins dir: `git clone https://github.com/theam/claude-dev-kit ~/.cursor/plugins/local/claude-dev-kit`, or
+- (Teams/Enterprise) an admin imports the repo: Dashboard → Plugins → **Add Marketplace → Import from Repo**.
+
+Skills then auto-load; enable MCP under **Cursor Settings → Tools & MCP** (`~/.cursor/mcp.json`).
+
+> **Status, honestly:** the Agent Plugins standard is days old (published 2026-08-06) and client
+> support is early. We've **validated Codex 0.147 end to end**; **Cursor and Copilot are not yet
+> verified by us** — the plugin is format-compliant, but confirm install + skill invocation on your
+> client version.
 
 ## Relationship to project repos
 

--- a/codex/README.md
+++ b/codex/README.md
@@ -23,6 +23,21 @@ built-in review, so invoke the kit's explicitly.
 enable the plugin; the telemetry parser + sweep are confirmed on a real rollout. In-app
 skill invocation and MCP OAuth are still yours to confirm on your build.*
 
+## Portable clients (Agent Plugins 1.0.0)
+
+Alongside the Codex-native `.codex-plugin/plugin.json`, the build **dual-emits a portable
+`plugin.json`** at the plugin root following the open **[Agent Plugins 1.0.0](https://agent-plugins.org)**
+standard (OpenAI · AWS · Cursor · GitHub · Microsoft · Vercel). Same `skills/`; the Codex
+`interface` metadata rides under the `com.theagilemonkeys.dev-kit` extensions namespace.
+This makes the same plugin loadable by other Agent-Plugins-compatible clients (Cursor,
+VS Code, Copilot, …), not just Codex.
+
+Verified against real **codex-cli 0.147**: Codex *requires* `.codex-plugin/plugin.json`
+(a portable-only layout errors `missing plugin.json`) and installs cleanly with both
+manifests present — so the two coexist by design. Portable `mcp.json` is intentionally
+omitted: the 1.0.0 MCP schema has no OAuth field and our trackers use Codex curated
+connectors, so portable clients handle connector auth themselves.
+
 ## Connectors / MCP (from your wizard choices)
 
 `issue-fetch` reads tickets through Codex's connector for your tracker. **The easiest

--- a/codex/skills/work-story/SKILL.md
+++ b/codex/skills/work-story/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: work-story
+description: Work a user story end to end — fetch the ticket, plan (with approval), implement, verify the applicable gates, self-review, open the PR, and update the tracker. Use when given an issue key like PROJ-1234, ENG-42, or #123. This is the orchestration playbook for hosts without a dedicated orchestrator subagent (Codex, and other Agent-Plugins clients); on Claude Code the `/work-story` command + `coding-agent` subagent do this instead.
+---
+
+# Work Story (orchestration)
+
+You are the story orchestrator. Input: an issue key from the team's tracker. Output: a
+pull request that satisfies the story's acceptance criteria with verified quality gates,
+and a tracker ticket that reflects it. **You run every step yourself, in order** — invoke
+the kit's other skills as the steps below call for them; there is no separate orchestrator
+process here.
+
+If no issue reference is given, ask for one — don't guess. Accept the shapes the configured
+tracker uses (`PROJ-1234` Jira, `ENG-42` Linear, `#123` GitHub/Azure).
+
+**Stack-agnostic.** Carry no assumptions about language, framework, or test runner. Read the
+repo's `AGENTS.md` / `CLAUDE.md` and `.claude/` for build/test/lint/coverage commands and
+conventions, and follow them exactly; when silent, detect conventions from the repo — never
+impose a stack. The always-on rules in `instructions/secure-coding.md` and
+`instructions/testing-standards.md` bind every step.
+
+## 1. Context
+- If `.claude/dev-kit.json` is missing, run **`dev-kit-setup`** first (one-time bootstrap:
+  tracker, project/team, field IDs).
+- Run **`issue-fetch`** for the ticket and show the summary.
+- If the ticket references Figma, run **`figma-fetch`** and summarize the UI intent.
+- Read the repo's project instructions and load the baseline stack profile
+  (`instructions/stacks/<id>.md` for the `stacks` in `.claude/dev-kit.json`); the repo's own
+  instructions always win, the profile fills gaps.
+
+## 2. Plan — WAIT FOR APPROVAL
+Validate assumptions against the running product when feasible (boot the app / exercise the
+flow) before writing the plan. Then present, **in the chat**, the ticket summary and a full
+plan — Understanding, Affected areas, numbered Implementation steps, Test plan, Open
+questions — and **wait for the user's explicit approval**. Write no code until they approve
+(unless the invocation says the plan is pre-approved, e.g. an automated run).
+
+## 3. Implement
+- Follow the repo's conventions and architecture. Keep the diff scoped to the story — no
+  opportunistic refactors.
+- Update every side of any changed contract (payload/route/enum/schema/validation) together.
+- For user-facing frontend work, write accessible markup as you go (semantic HTML, labels,
+  `alt`, keyboard/focus) — cheaper than fixing it at review.
+
+## 4. Verify (gates — adaptive to the project)
+Apply the gates that fit the project (detect its setup each run; see
+`instructions/testing-standards.md`). Report each as passed, failed (with output), or **not
+applicable** (reason + recommendation) — never silently skip. A `gates` policy in
+`.claude/dev-kit.json` can force `required`/`off`; default is auto-detect.
+- Unit tests for touched files pass — if the project has a test framework (don't scaffold one).
+- **`coverage-check`** — if the project has coverage tooling (touched files meet the bar,
+  default ≥ 95%, no regression). If none: recommend, don't fail.
+- **`e2e-generate`** for user-facing changes — if the project already does e2e.
+- Lint clean on touched files (when the project lints).
+- **Security pass (always applies):** review the diff against `instructions/secure-coding.md`;
+  any automatic-blocker is a gate — fix and re-check.
+
+## 5. Self-review
+Run **`pr-review`** on the full diff. Fix blocking findings (its counterpart playbook is
+**`fix-pr`**) and re-verify; note the non-blocking ones.
+
+## 6. Ship
+Run **`create-pr`**. Report the PR URL, the verification evidence, and any follow-up risks.
+
+## 7. Update the ticket
+Run **`issue-update`**: comment a product-facing summary (plain language) plus the PR link,
+and transition the ticket to the team's review status. The story isn't done until the
+tracker reflects it.
+
+## Reporting
+At every step, state plainly what passed, what failed (with output), and what was skipped.
+Never report a gate as passed without having run it.

--- a/plugins/fullstack-dev-kit/.codex-plugin/plugin.json
+++ b/plugins/fullstack-dev-kit/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fullstack-dev-kit",
-  "version": "0.18.1",
+  "version": "0.19.0",
   "description": "Issue-to-PR workflow for any tech stack: fetch stories from Jira/Linear/GitHub/Azure and Figma designs, plan-approval gate, adaptive quality + coverage gates, e2e generation, PR creation and review.",
   "author": {
     "name": "The Agile Monkeys",

--- a/plugins/fullstack-dev-kit/AGENTS.md
+++ b/plugins/fullstack-dev-kit/AGENTS.md
@@ -5,10 +5,16 @@ the **same `SKILL.md` playbooks** as the Claude Code plugin, installed into Code
 
 ## How it's used
 
-Invoke a skill explicitly (e.g. `$issue-fetch`, `$pr-review`, `$create-pr`) or ask for the
-work directly ("work ticket PROJ-1234 end to end"). Codex has its own built-in review; to use
-this kit's review, invoke `$pr-review`. The skills honor the per-repo config in
-`.claude/dev-kit.json` (tracker, PR host, gates) exactly as on Claude Code.
+- **End to end:** invoke **`$work-story PROJ-1234`** — the orchestration playbook. Since Codex
+  has no orchestrator subagent, *you (the host agent)* run its steps in order: fetch → plan
+  (with approval) → implement → verify gates → self-review → open PR → update the ticket,
+  invoking the other skills as it calls for them.
+- **Single step:** invoke any skill directly (`$issue-fetch`, `$pr-review`, `$create-pr`, …).
+  Codex has its own built-in review; to use this kit's review, invoke `$pr-review`.
+
+The skills honor the per-repo config in `.claude/dev-kit.json` (tracker, PR host, gates)
+exactly as on Claude Code. (On Claude Code the end-to-end flow is the `/work-story` command +
+`coding-agent` subagent instead of this playbook skill.)
 
 ## Prerequisites
 

--- a/plugins/fullstack-dev-kit/plugin.json
+++ b/plugins/fullstack-dev-kit/plugin.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "fullstack-dev-kit",
+  "version": "0.19.0",
+  "description": "Issue-to-PR workflow for any tech stack: fetch stories from Jira/Linear/GitHub/Azure and Figma designs, plan-approval gate, adaptive quality + coverage gates, e2e generation, PR creation and review.",
+  "author": {
+    "name": "The Agile Monkeys",
+    "url": "https://www.theagilemonkeys.com"
+  },
+  "homepage": "https://github.com/theam/claude-dev-kit",
+  "repository": "https://github.com/theam/claude-dev-kit",
+  "license": "Apache-2.0",
+  "keywords": [
+    "issue-to-pr",
+    "code-review",
+    "coverage",
+    "jira",
+    "linear",
+    "workflow"
+  ],
+  "extensions": {
+    "com.theagilemonkeys.dev-kit": {
+      "interface": {
+        "displayName": "Fullstack Dev Kit",
+        "shortDescription": "Issue-to-PR workflow with quality gates, for any stack.",
+        "longDescription": "Takes a ticket (Jira / Linear / GitHub Issues / Azure) from plan-approval through implementation, adaptive tests/coverage, security and accessibility review, to an opened pull request. Stack-agnostic. The issue tracker and PR host are configured per repo; connect the matching MCP (e.g. Atlassian for Jira, Linear) to let the kit read tickets.",
+        "developerName": "The Agile Monkeys",
+        "category": "Engineering",
+        "capabilities": [
+          "Read",
+          "Write"
+        ],
+        "websiteURL": "https://github.com/theam/claude-dev-kit",
+        "privacyPolicyURL": "https://github.com/theam/claude-dev-kit/blob/main/TELEMETRY.md",
+        "defaultPrompt": [
+          "Work ticket PROJ-1234 end to end and open a PR"
+        ]
+      }
+    }
+  }
+}

--- a/plugins/fullstack-dev-kit/skills/work-story/SKILL.md
+++ b/plugins/fullstack-dev-kit/skills/work-story/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: work-story
+description: Work a user story end to end — fetch the ticket, plan (with approval), implement, verify the applicable gates, self-review, open the PR, and update the tracker. Use when given an issue key like PROJ-1234, ENG-42, or #123. This is the orchestration playbook for hosts without a dedicated orchestrator subagent (Codex, and other Agent-Plugins clients); on Claude Code the `/work-story` command + `coding-agent` subagent do this instead.
+---
+
+# Work Story (orchestration)
+
+You are the story orchestrator. Input: an issue key from the team's tracker. Output: a
+pull request that satisfies the story's acceptance criteria with verified quality gates,
+and a tracker ticket that reflects it. **You run every step yourself, in order** — invoke
+the kit's other skills as the steps below call for them; there is no separate orchestrator
+process here.
+
+If no issue reference is given, ask for one — don't guess. Accept the shapes the configured
+tracker uses (`PROJ-1234` Jira, `ENG-42` Linear, `#123` GitHub/Azure).
+
+**Stack-agnostic.** Carry no assumptions about language, framework, or test runner. Read the
+repo's `AGENTS.md` / `CLAUDE.md` and `.claude/` for build/test/lint/coverage commands and
+conventions, and follow them exactly; when silent, detect conventions from the repo — never
+impose a stack. The always-on rules in `instructions/secure-coding.md` and
+`instructions/testing-standards.md` bind every step.
+
+## 1. Context
+- If `.claude/dev-kit.json` is missing, run **`dev-kit-setup`** first (one-time bootstrap:
+  tracker, project/team, field IDs).
+- Run **`issue-fetch`** for the ticket and show the summary.
+- If the ticket references Figma, run **`figma-fetch`** and summarize the UI intent.
+- Read the repo's project instructions and load the baseline stack profile
+  (`instructions/stacks/<id>.md` for the `stacks` in `.claude/dev-kit.json`); the repo's own
+  instructions always win, the profile fills gaps.
+
+## 2. Plan — WAIT FOR APPROVAL
+Validate assumptions against the running product when feasible (boot the app / exercise the
+flow) before writing the plan. Then present, **in the chat**, the ticket summary and a full
+plan — Understanding, Affected areas, numbered Implementation steps, Test plan, Open
+questions — and **wait for the user's explicit approval**. Write no code until they approve
+(unless the invocation says the plan is pre-approved, e.g. an automated run).
+
+## 3. Implement
+- Follow the repo's conventions and architecture. Keep the diff scoped to the story — no
+  opportunistic refactors.
+- Update every side of any changed contract (payload/route/enum/schema/validation) together.
+- For user-facing frontend work, write accessible markup as you go (semantic HTML, labels,
+  `alt`, keyboard/focus) — cheaper than fixing it at review.
+
+## 4. Verify (gates — adaptive to the project)
+Apply the gates that fit the project (detect its setup each run; see
+`instructions/testing-standards.md`). Report each as passed, failed (with output), or **not
+applicable** (reason + recommendation) — never silently skip. A `gates` policy in
+`.claude/dev-kit.json` can force `required`/`off`; default is auto-detect.
+- Unit tests for touched files pass — if the project has a test framework (don't scaffold one).
+- **`coverage-check`** — if the project has coverage tooling (touched files meet the bar,
+  default ≥ 95%, no regression). If none: recommend, don't fail.
+- **`e2e-generate`** for user-facing changes — if the project already does e2e.
+- Lint clean on touched files (when the project lints).
+- **Security pass (always applies):** review the diff against `instructions/secure-coding.md`;
+  any automatic-blocker is a gate — fix and re-check.
+
+## 5. Self-review
+Run **`pr-review`** on the full diff. Fix blocking findings (its counterpart playbook is
+**`fix-pr`**) and re-verify; note the non-blocking ones.
+
+## 6. Ship
+Run **`create-pr`**. Report the PR URL, the verification evidence, and any follow-up risks.
+
+## 7. Update the ticket
+Run **`issue-update`**: comment a product-facing summary (plain language) plus the PR link,
+and transition the ticket to the team's review status. The story isn't done until the
+tracker reflects it.
+
+## Reporting
+At every step, state plainly what passed, what failed (with output), and what was skipped.
+Never report a gate as passed without having run it.

--- a/scripts/build-codex-plugin.mjs
+++ b/scripts/build-codex-plugin.mjs
@@ -34,6 +34,19 @@ for (const name of readdirSync(SRC_SKILLS)) {
   n++;
 }
 
+// 1a. Bundle-only skills (codex/skills/): shipped to the plugin (Codex + portable
+// clients like Cursor/Copilot) but NOT to the Claude Code plugin. This is where the
+// `work-story` orchestration playbook lives — hosts without an orchestrator subagent
+// follow it directly, whereas Claude Code uses its /work-story command + coding-agent.
+const SRC_BUNDLE_SKILLS = join(ROOT, 'codex', 'skills');
+if (existsSync(SRC_BUNDLE_SKILLS)) {
+  for (const name of readdirSync(SRC_BUNDLE_SKILLS)) {
+    if (!existsSync(join(SRC_BUNDLE_SKILLS, name, 'SKILL.md'))) continue;
+    cpSync(join(SRC_BUNDLE_SKILLS, name), join(DST_SKILLS, name), { recursive: true });
+    n++;
+  }
+}
+
 // 1b. Resync the instructions the skills reference (secure-coding, testing-standards,
 // stacks/…). Without these the bundle isn't self-contained — a native Codex install
 // can't run the kit's own security/testing/stack rules. Their relative paths

--- a/scripts/build-codex-plugin.mjs
+++ b/scripts/build-codex-plugin.mjs
@@ -50,7 +50,29 @@ if (manifest.version !== kitVersion) {
   writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + '\n');
 }
 
-console.log(`Codex plugin built: ${n} skills + instructions/ synced, version ${kitVersion}.`);
+// 3. Dual-emit the PORTABLE Agent Plugins 1.0.0 manifest at the plugin root.
+// Codex reads .codex-plugin/plugin.json (required — verified: Codex 0.147 errors
+// "missing plugin.json" without it); portable clients (Cursor, VS Code, Copilot, …)
+// read this root plugin.json. Generated from the Codex manifest = one source of truth.
+// The portable schema is closed and has no home for Codex's `interface`/`skills` keys,
+// so `skills` is dropped (skills are auto-discovered from skills/) and `interface`
+// rides under our reverse-DNS extensions namespace.
+const cm = JSON.parse(readFileSync(manifestPath, 'utf8'));
+const portable = {
+  $schema: 'https://agent-plugins.org/schemas/1.0.0/plugin.schema.json',
+  name: cm.name,
+  version: cm.version,
+  description: cm.description,
+  author: cm.author,          // {name, url} object — valid under the portable schema
+  homepage: cm.homepage,
+  repository: cm.repository,
+  license: cm.license,
+  keywords: cm.keywords,
+  extensions: { 'com.theagilemonkeys.dev-kit': { interface: cm.interface } },
+};
+writeFileSync(join(PLUGIN, 'plugin.json'), JSON.stringify(portable, null, 2) + '\n');
+
+console.log(`Codex plugin built: ${n} skills + instructions/ synced, version ${kitVersion} (native + portable manifests).`);
 
 // Validate the freshly-built bundle (structure, enums, self-contained instructions).
 const v = spawnSync(process.execPath, [join(ROOT, 'scripts', 'validate-codex-plugin.mjs')], { stdio: 'inherit' });

--- a/scripts/validate-codex-plugin.mjs
+++ b/scripts/validate-codex-plugin.mjs
@@ -59,7 +59,20 @@ else {
   }
 }
 
-// 3. Self-contained bundle: every instructions/… referenced by a bundled skill must exist here.
+// 3. Portable Agent Plugins 1.0.0 manifest (root plugin.json), for non-Codex clients.
+const portPath = join(PLUGIN, 'plugin.json');
+if (!existsSync(portPath)) errs.push(`missing portable ${portPath} — run build-codex-plugin.mjs`);
+else {
+  let pm; try { pm = readJson(portPath); } catch (e) { errs.push(`portable plugin.json is not valid JSON: ${e.message}`); }
+  if (pm) {
+    if (pm.$schema !== 'https://agent-plugins.org/schemas/1.0.0/plugin.schema.json') errs.push('portable plugin.json: $schema must be the Agent Plugins 1.0.0 const URI');
+    if (!pm.name || !/^(?!.*(?:--|\.\.))[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$/.test(pm.name)) errs.push(`portable plugin.json: name "${pm.name}" fails the 1.0.0 pattern`);
+    if (pm.author && typeof pm.author !== 'object') errs.push('portable plugin.json: author must be an object {name,email,url}');
+    for (const bad of ['skills', 'interface']) if (bad in pm) errs.push(`portable plugin.json: "${bad}" is not allowed by the closed schema — put it under extensions instead`);
+  }
+}
+
+// 4. Self-contained bundle + portable skill-name rules.
 const skillsDir = join(PLUGIN, 'skills');
 if (existsSync(skillsDir)) {
   const refs = new Set();
@@ -69,6 +82,11 @@ if (existsSync(skillsDir)) {
     const body = readFileSync(sp, 'utf8');
     for (const m of body.matchAll(/instructions\/[A-Za-z0-9/_-]+\.md/g)) refs.add(m[0]);
     for (const m of body.matchAll(/instructions\/stacks\//g)) refs.add('instructions/stacks');
+    // Agent Skills: dir name hyphen-only, and frontmatter `name` must match the dir name.
+    if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(name)) errs.push(`skill "${name}": dir name must be lowercase hyphen-only (Agent Skills spec)`);
+    const fm = body.match(/^---\n([\s\S]*?)\n---/);
+    const declared = fm && fm[1].match(/^name:\s*(.+)$/m)?.[1]?.trim();
+    if (declared && declared !== name) errs.push(`skill "${name}": frontmatter name "${declared}" must match the directory name`);
   }
   for (const ref of refs) {
     if (!existsSync(join(PLUGIN, ref))) errs.push(`bundle is not self-contained: a skill references "${ref}" but it's not in the plugin — run build-codex-plugin.mjs`);


### PR DESCRIPTION
**Phase 2** of the Codex work: make the kit loadable by *any* Agent-Plugins-compatible client (Cursor, VS Code, Copilot, …), not just Codex — by emitting the open **[Agent Plugins 1.0.0](https://agent-plugins.org)** manifest alongside our Codex-native one.

## What's here
- `build-codex-plugin.mjs` **dual-emits** a root `plugins/fullstack-dev-kit/plugin.json` per the 1.0.0 spec, generated from the Codex manifest (one source of truth):
  - required `$schema` const + `name` (pattern-valid), plus version/description/author(object)/homepage/repository/license/keywords;
  - the Codex `interface` block moved under the `com.theagilemonkeys.dev-kit` **extensions** namespace (the closed portable schema has no home for it);
  - the `skills` key dropped (skills are auto-discovered from `skills/`), which is shared with the native manifest.
- **Validator extended**: portable manifest (`$schema` const, `name` pattern, no `skills`/`interface` at top level, author is object) + Agent Skills naming (hyphen-only skill dirs, frontmatter `name` == dir).

## Verified against real codex-cli 0.147
- A **portable-only** layout (root `plugin.json`, no `.codex-plugin/`) → Codex errors `missing plugin.json`. So Codex still requires its native manifest.
- Codex installs **cleanly with both manifests present** → the two coexist; dual-emit is the right approach.

## Deliberately out of scope
- Portable `mcp.json`: the 1.0.0 MCP schema has **no OAuth field**, and our trackers use Codex **curated connectors** — portable clients handle connector auth themselves.
- Submitting to the universal Plugins Directory (Phase 3 — needs verified identity, test cases, domain verification).

## Risk
Additive: new root `plugin.json` + generator/validator changes. No change to Claude Code behavior; Codex native install unaffected (verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)