### PR TITLE
feat(wizard): auto-install for Cursor (v0.19.1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fullstack-dev-kit",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "Issue-to-PR workflow kit for any tech stack. Fetch a user story from your tracker (Jira, Linear, GitHub Issues, Azure DevOps) and any linked Figma designs, implement with plan approval, enforce >95% coverage and a security pass, generate e2e tests, open the PR, fix review findings, and move the ticket to review.",
   "license": "Apache-2.0",
   "homepage": "https://github.com/theam/claude-dev-kit",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ a release is only "live" for users once that is bumped and published.
 
 ## [Unreleased]
 
+## [0.19.1] - 2026-08-10
+### Added
+- **Wizard installs for Cursor too.** `create-dev-kit` now detects Cursor and, on opt-in, drops the portable plugin into `~/.cursor/plugins/local/fullstack-dev-kit` (skills auto-load on restart; MCP enabled from Cursor Settings → Tools & MCP). Additive and idempotent; no telemetry on Cursor (tracking stays Codex/Claude only). Copilot install remains manual (its "Install Plugin From Source" is a VS Code UI action, not scriptable). Wizard package bumped to 0.1.1 — republish to npm for users to get it.
+### Changed
+- Refactored the shared `~/.dev-kit` checkout into an `ensureKitCheckout()` helper used by both the Codex sweep and the Cursor install.
+
 ## [0.19.0] - 2026-08-10
 ### Added
 - **Portable Agent Plugins 1.0.0 manifest (multi-client).** `build-codex-plugin.mjs` now **dual-emits** a root `plugins/fullstack-dev-kit/plugin.json` following the open [Agent Plugins 1.0.0](https://agent-plugins.org) standard (OpenAI · AWS · Cursor · GitHub · Microsoft · Vercel), alongside the Codex-native `.codex-plugin/plugin.json`. Generated from one source; the `interface` metadata rides under the `com.theagilemonkeys.dev-kit` extensions namespace; `skills/` is shared. The same plugin is now loadable by other Agent-Plugins-compatible clients (Cursor, VS Code, Copilot, …), not just Codex.

--- a/README.md
+++ b/README.md
@@ -237,11 +237,12 @@ automatically. Add your tracker's MCP via **MCP: Add Server** (or `.vscode/mcp.j
 labeled Experimental — behavior may shift.*
 
 ### Cursor — *no git-URL installer yet*
-Cursor has no “install from git URL” command today. Either:
-- clone into the local plugins dir: `git clone https://github.com/theam/claude-dev-kit ~/.cursor/plugins/local/claude-dev-kit`, or
+Cursor has no “install from git URL” command today, so:
+- **Easiest:** run **`npm create @theagilemonkeys/dev-kit`** — the wizard detects Cursor and drops the portable plugin into `~/.cursor/plugins/local/fullstack-dev-kit` for you, or
+- clone it yourself: `git clone https://github.com/theam/claude-dev-kit ~/.cursor/plugins/local/claude-dev-kit`, or
 - (Teams/Enterprise) an admin imports the repo: Dashboard → Plugins → **Add Marketplace → Import from Repo**.
 
-Skills then auto-load; enable MCP under **Cursor Settings → Tools & MCP** (`~/.cursor/mcp.json`).
+Restart Cursor; skills then auto-load. Enable MCP under **Cursor Settings → Tools & MCP** (`~/.cursor/mcp.json`). No telemetry on Cursor.
 
 > **Status, honestly:** the Agent Plugins standard is days old (published 2026-08-06) and client
 > support is early. We've **validated Codex 0.147 end to end**; **Cursor and Copilot are not yet

--- a/packages/create-dev-kit/index.mjs
+++ b/packages/create-dev-kit/index.mjs
@@ -10,7 +10,7 @@
  */
 import { createInterface } from 'node:readline/promises';
 import { stdin, stdout, exit } from 'node:process';
-import { readFileSync, writeFileSync, mkdirSync, existsSync, readdirSync, cpSync } from 'node:fs';
+import { readFileSync, writeFileSync, mkdirSync, existsSync, readdirSync, cpSync, rmSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
 import { randomUUID } from 'node:crypto';
@@ -62,6 +62,23 @@ function codexBin() {
   return null;
 }
 
+// Clone/update the stable kit checkout at ~/.dev-kit (shared by the Codex telemetry
+// sweep and the Cursor install). Honors DEVKIT_CODEX_REF for branch testing. Returns
+// true if the plugin is present in the checkout afterward.
+function ensureKitCheckout(ref) {
+  if (!have('git')) return existsSync(join(KIT_HOME, 'plugins', 'fullstack-dev-kit'));
+  if (existsSync(join(KIT_HOME, '.git'))) {
+    if (ref) {
+      spawnSync('git', ['-C', KIT_HOME, 'fetch', 'origin', ref], { stdio: 'ignore' });
+      spawnSync('git', ['-C', KIT_HOME, 'checkout', ref], { stdio: 'ignore' });
+    }
+    spawnSync('git', ['-C', KIT_HOME, 'pull', '--ff-only'], { stdio: 'ignore' });
+  } else {
+    spawnSync('git', ['clone', '--depth', '1', ...(ref ? ['--branch', ref] : []), KIT_REPO, KIT_HOME], { stdio: 'ignore' });
+  }
+  return existsSync(join(KIT_HOME, 'plugins', 'fullstack-dev-kit'));
+}
+
 // Codex integration. Codex has its own plugin system (parallel to Claude Code), so
 // we install the kit as a NATIVE Codex plugin from our marketplace, register the MCP
 // servers the wizard's choices imply, and schedule the anonymous telemetry sweep.
@@ -108,15 +125,7 @@ async function maybeSetupCodex({ consent, tracker, figma }) {
   if (!have('git')) {
     console.log(dim('   git not found — skipping the telemetry sweep (plugin + MCP are set up).'));
   } else {
-    if (existsSync(join(KIT_HOME, '.git'))) {
-      if (CODEX_REF) {
-        spawnSync('git', ['-C', KIT_HOME, 'fetch', 'origin', CODEX_REF], { stdio: 'ignore' });
-        spawnSync('git', ['-C', KIT_HOME, 'checkout', CODEX_REF], { stdio: 'ignore' });
-      }
-      spawnSync('git', ['-C', KIT_HOME, 'pull', '--ff-only'], { stdio: 'ignore' });
-    } else {
-      spawnSync('git', ['clone', '--depth', '1', ...(CODEX_REF ? ['--branch', CODEX_REF] : []), KIT_REPO, KIT_HOME], { stdio: 'ignore' });
-    }
+    ensureKitCheckout(CODEX_REF);
     const plistTmpl = join(KIT_HOME, 'codex', 'dev-kit-codex-sweep.plist');
     if (process.platform === 'darwin' && existsSync(plistTmpl)) {
       try {
@@ -139,6 +148,26 @@ async function maybeSetupCodex({ consent, tracker, figma }) {
 
   console.log(dim('\n   Restart Codex, then invoke a skill (e.g. $pr-review) or ask for the work directly.'));
   if (!consent) console.log(dim('   (telemetry is OFF — the sweep no-ops until you opt in)'));
+}
+
+// Cursor loads plugins from ~/.cursor/plugins/local/. We drop the portable plugin there
+// (skills auto-load; MCP is enabled from Cursor Settings → Tools & MCP). No telemetry on
+// Cursor — usage tracking is Codex/Claude only.
+async function maybeSetupCursor() {
+  const cursorPresent = existsSync(join(homedir(), '.cursor')) || existsSync('/Applications/Cursor.app');
+  if (!cursorPresent) return;
+  console.log(`\n${b('7. Cursor (also detected)')} ${dim('(experimental — not verified by us)')}`);
+  if (!await yn('   Install the kit for Cursor too?', true)) return;
+  if (!have('git')) { console.log(dim('   git not found — skipping. Install git and re-run.')); return; }
+  if (!ensureKitCheckout(process.env.DEVKIT_CODEX_REF)) { console.log(dim('   could not fetch the kit — skipping Cursor setup.')); return; }
+  try {
+    const dst = join(homedir(), '.cursor', 'plugins', 'local', 'fullstack-dev-kit');
+    mkdirSync(dirname(dst), { recursive: true });
+    rmSync(dst, { recursive: true, force: true });   // idempotent: replace any prior copy
+    cpSync(join(KIT_HOME, 'plugins', 'fullstack-dev-kit'), dst, { recursive: true });
+    console.log(`   • ${dst} ${dim('(portable plugin — restart Cursor; skills auto-load)')}`);
+    console.log(dim('   Enable your tracker MCP in Cursor Settings → Tools & MCP. (No telemetry on Cursor.)'));
+  } catch (e) { console.log(dim('   could not install for Cursor: ' + (e?.message || e))); }
 }
 
 async function main() {
@@ -253,6 +282,7 @@ async function main() {
   }
 
   await maybeSetupCodex({ consent, tracker, figma });
+  await maybeSetupCursor();
 
   console.log(`\n${dim('Restart your Claude session, then run')} ${b('/fullstack-dev-kit:work-story <TICKET>')}\n`);
 }

--- a/packages/create-dev-kit/package.json
+++ b/packages/create-dev-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@theagilemonkeys/create-dev-kit",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Interactive setup for the claude-dev-kit Claude Code plugin: pick your issue tracker and design tool, review and opt in (or out) of anonymous telemetry, set your organisation, and write the config.",
   "license": "Apache-2.0",
   "type": "module",

--- a/plugins/fullstack-dev-kit/.codex-plugin/plugin.json
+++ b/plugins/fullstack-dev-kit/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fullstack-dev-kit",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "Issue-to-PR workflow for any tech stack: fetch stories from Jira/Linear/GitHub/Azure and Figma designs, plan-approval gate, adaptive quality + coverage gates, e2e generation, PR creation and review.",
   "author": {
     "name": "The Agile Monkeys",

--- a/plugins/fullstack-dev-kit/plugin.json
+++ b/plugins/fullstack-dev-kit/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "fullstack-dev-kit",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "Issue-to-PR workflow for any tech stack: fetch stories from Jira/Linear/GitHub/Azure and Figma designs, plan-approval gate, adaptive quality + coverage gates, e2e generation, PR creation and review.",
   "author": {
     "name": "The Agile Monkeys",


### PR DESCRIPTION
The `create-dev-kit` wizard now detects **Cursor** and, on opt-in, installs the portable plugin into `~/.cursor/plugins/local/fullstack-dev-kit` (skills auto-load on restart; MCP enabled from Cursor Settings → Tools & MCP).

- Additive + idempotent (rm+copy); gated behind detection and a Y/n prompt.
- **No telemetry on Cursor** — tracking stays Codex/Claude only (documented).
- Copilot stays manual (its "Install Plugin From Source" is a VS Code UI action, not scriptable).
- Refactored the shared `~/.dev-kit` checkout into `ensureKitCheckout()`, reused by the Codex sweep and the Cursor install.
- README Cursor section updated; wizard package → 0.1.1 (needs an npm republish to reach users).

No change to Claude Code / Codex behavior. Copy logic tested idempotent in isolation; wizard syntax-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)