### PR TITLE
fix(wizard): agent-aware install step (v0.19.2)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fullstack-dev-kit",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "description": "Issue-to-PR workflow kit for any tech stack. Fetch a user story from your tracker (Jira, Linear, GitHub Issues, Azure DevOps) and any linked Figma designs, implement with plan approval, enforce >95% coverage and a security pass, generate e2e tests, open the PR, fix review findings, and move the ticket to review.",
   "license": "Apache-2.0",
   "homepage": "https://github.com/theam/claude-dev-kit",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ a release is only "live" for users once that is bumped and published.
 
 ## [Unreleased]
 
+## [0.19.2] - 2026-08-10
+### Changed
+- **Wizard install step is now agent-aware.** It no longer assumes Claude Code: the "install for Claude Code" step only appears **when the `claude` CLI is detected** (was an unconditional "Install with the Claude CLI?"), and the closing hint shows the right entry point per host (Claude `/fullstack-dev-kit:work-story` vs Codex/Cursor `$work-story`). Sections renumbered (Claude 6 · Codex 7 · Cursor 8); intro reworded for the multi-client kit. Wizard package → 0.1.2 (republish to npm for users to get it).
+
 ## [0.19.1] - 2026-08-10
 ### Added
 - **Wizard installs for Cursor too.** `create-dev-kit` now detects Cursor and, on opt-in, drops the portable plugin into `~/.cursor/plugins/local/fullstack-dev-kit` (skills auto-load on restart; MCP enabled from Cursor Settings → Tools & MCP). Additive and idempotent; no telemetry on Cursor (tracking stays Codex/Claude only). Copilot install remains manual (its "Install Plugin From Source" is a VS Code UI action, not scriptable). Wizard package bumped to 0.1.1 — republish to npm for users to get it.

--- a/packages/create-dev-kit/index.mjs
+++ b/packages/create-dev-kit/index.mjs
@@ -86,7 +86,7 @@ async function maybeSetupCodex({ consent, tracker, figma }) {
   const codex = codexBin();
   const codexPresent = !!codex || existsSync(join(homedir(), '.codex'));
   if (!codexPresent) return;
-  console.log(`\n${b('6. Codex (also detected)')} ${dim('(experimental)')}`);
+  console.log(`\n${b('7. Codex (detected)')} ${dim('(experimental)')}`);
   if (!await yn('   Set the kit up for Codex too?', true)) return;
   if (!codex) { console.log(dim('   Codex CLI not found on PATH or in /Applications/Codex.app — skipping.')); return; }
 
@@ -156,7 +156,7 @@ async function maybeSetupCodex({ consent, tracker, figma }) {
 async function maybeSetupCursor() {
   const cursorPresent = existsSync(join(homedir(), '.cursor')) || existsSync('/Applications/Cursor.app');
   if (!cursorPresent) return;
-  console.log(`\n${b('7. Cursor (also detected)')} ${dim('(experimental — not verified by us)')}`);
+  console.log(`\n${b('8. Cursor (detected)')} ${dim('(experimental — not verified by us)')}`);
   if (!await yn('   Install the kit for Cursor too?', true)) return;
   if (!have('git')) { console.log(dim('   git not found — skipping. Install git and re-run.')); return; }
   if (!ensureKitCheckout(process.env.DEVKIT_CODEX_REF)) { console.log(dim('   could not fetch the kit — skipping Cursor setup.')); return; }
@@ -171,7 +171,7 @@ async function maybeSetupCursor() {
 }
 
 async function main() {
-  console.log(`\n${b('claude-dev-kit setup')}\n${dim('Issue-to-PR workflow for Claude Code & Codex — by The Agile Monkeys')}\n`);
+  console.log(`\n${b('claude-dev-kit setup')}\n${dim('Issue-to-PR workflow for Claude Code, Codex & Cursor — by The Agile Monkeys')}\n`);
 
   // 1. Issue tracker
   console.log(b('1. Issue tracker'));
@@ -261,30 +261,32 @@ async function main() {
   console.log(`  • ${repoCfgPath} ${dim('(commit this — shared by your team)')}`);
   console.log(`  • ${consentPath} ${dim('(per-user, private — telemetry ' + (consent ? 'ON' : 'OFF') + ')')}`);
 
-  if (await yn('\nInstall the plugin now with the Claude CLI?', true)) {
-    for (const args of [
-      ['plugin', 'marketplace', 'add', 'theam/claude-dev-kit'],
-      ['plugin', 'install', 'fullstack-dev-kit@claude-dev-kit'],
-    ]) {
-      console.log(dim(`  $ claude ${args.join(' ')}`));
-      const r = spawnSync('claude', args, { stdio: 'inherit' });
-      if (r.error) {
-        console.log(`  ${dim('claude CLI not found — run these two commands yourself:')}`);
-        console.log('    claude plugin marketplace add theam/claude-dev-kit');
-        console.log('    claude plugin install fullstack-dev-kit@claude-dev-kit');
-        break;
+  // Install per detected agent — the kit is multi-client, so Claude Code is one option,
+  // not the assumed host. Each agent gets its own opt-in step below.
+  if (have('claude')) {
+    console.log(`\n${b('6. Claude Code (detected)')}`);
+    if (await yn('   Install the plugin for Claude Code now?', true)) {
+      for (const args of [
+        ['plugin', 'marketplace', 'add', 'theam/claude-dev-kit'],
+        ['plugin', 'install', 'fullstack-dev-kit@claude-dev-kit'],
+      ]) {
+        console.log(dim(`   $ claude ${args.join(' ')}`));
+        if (spawnSync('claude', args, { stdio: 'inherit' }).error) {
+          console.log(dim('   claude CLI errored mid-run — run: claude plugin marketplace add theam/claude-dev-kit && claude plugin install fullstack-dev-kit@claude-dev-kit'));
+          break;
+        }
       }
+    } else {
+      console.log(dim('   Later: claude plugin marketplace add theam/claude-dev-kit && claude plugin install fullstack-dev-kit@claude-dev-kit'));
     }
-  } else {
-    console.log(dim('\n  Install later with:'));
-    console.log('    claude plugin marketplace add theam/claude-dev-kit');
-    console.log('    claude plugin install fullstack-dev-kit@claude-dev-kit');
   }
 
   await maybeSetupCodex({ consent, tracker, figma });
   await maybeSetupCursor();
 
-  console.log(`\n${dim('Restart your Claude session, then run')} ${b('/fullstack-dev-kit:work-story <TICKET>')}\n`);
+  console.log(`\n${b('Done.')} ${dim('Restart your agent, then start a story:')}`);
+  console.log(dim('  • Claude Code:  ') + b('/fullstack-dev-kit:work-story <TICKET>'));
+  console.log(dim('  • Codex / Cursor:  ') + b('$work-story <TICKET>') + dim('  (or invoke any skill, e.g. $pr-review)') + '\n');
 }
 
 main().catch((e) => { console.error(e?.message || e); exit(1); }).finally(() => rl.close());

--- a/packages/create-dev-kit/package.json
+++ b/packages/create-dev-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@theagilemonkeys/create-dev-kit",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Interactive setup for the claude-dev-kit Claude Code plugin: pick your issue tracker and design tool, review and opt in (or out) of anonymous telemetry, set your organisation, and write the config.",
   "license": "Apache-2.0",
   "type": "module",

--- a/plugins/fullstack-dev-kit/.codex-plugin/plugin.json
+++ b/plugins/fullstack-dev-kit/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fullstack-dev-kit",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "description": "Issue-to-PR workflow for any tech stack: fetch stories from Jira/Linear/GitHub/Azure and Figma designs, plan-approval gate, adaptive quality + coverage gates, e2e generation, PR creation and review.",
   "author": {
     "name": "The Agile Monkeys",

--- a/plugins/fullstack-dev-kit/plugin.json
+++ b/plugins/fullstack-dev-kit/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "fullstack-dev-kit",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "description": "Issue-to-PR workflow for any tech stack: fetch stories from Jira/Linear/GitHub/Azure and Figma designs, plan-approval gate, adaptive quality + coverage gates, e2e generation, PR creation and review.",
   "author": {
     "name": "The Agile Monkeys",


### PR DESCRIPTION
Now that the kit is multi-client, the wizard no longer assumes Claude Code.

- The 'install for Claude Code' step appears **only when the `claude` CLI is detected** (was an unconditional *"Install with the Claude CLI?"*).
- Closing hint is host-aware: Claude `/fullstack-dev-kit:work-story` vs Codex/Cursor `$work-story`.
- Sections renumbered (Claude 6 / Codex 7 / Cursor 8); intro reworded.

Config-only wizard UX; no behavior change to any host's plugin. Wizard package → 0.1.2 (republish to npm to reach users).

🤖 Generated with [Claude Code](https://claude.com/claude-code)