### PR TITLE
fix(submission): interface.category → Developer Tools (v0.19.5)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fullstack-dev-kit",
-  "version": "0.19.4",
+  "version": "0.19.5",
   "description": "Issue-to-PR workflow kit for any tech stack. Fetch a user story from your tracker (Jira, Linear, GitHub Issues, Azure DevOps) and any linked Figma designs, implement with plan approval, enforce >95% coverage and a security pass, generate e2e tests, open the PR, fix review findings, and move the ticket to review.",
   "license": "Apache-2.0",
   "homepage": "https://github.com/theam/claude-dev-kit",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ a release is only "live" for users once that is bumped and published.
 
 ## [Unreleased]
 
+## [0.19.5] - 2026-08-17
+### Fixed
+- **Listing `interface.category`.** OpenAI's plugin uploader rejects `Engineering`; changed to **`Developer Tools`** (a valid category in the portal's enum). Mirrored to the portable manifest by the build. Unblocks the OpenAI directory submission.
+
 ## [0.19.4] - 2026-08-14
 ### Added
 - **Listing screenshots.** Wired 3 workflow screenshots into the plugin `interface` (mirrored to the portable manifest): the GitHub PR (AI-generated badge + verification evidence), the Codex plan-approval gate, and the updated Jira ticket — in `plugins/fullstack-dev-kit/assets/screenshots/`. With this, the listing metadata is complete. (Raw captures for now; design can drop in cropped/anonymized versions under the same filenames.)

--- a/plugins/fullstack-dev-kit/.codex-plugin/plugin.json
+++ b/plugins/fullstack-dev-kit/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fullstack-dev-kit",
-  "version": "0.19.4",
+  "version": "0.19.5",
   "description": "Issue-to-PR workflow for any tech stack: fetch stories from Jira/Linear/GitHub/Azure and Figma designs, plan-approval gate, adaptive quality + coverage gates, e2e generation, PR creation and review.",
   "author": {
     "name": "The Agile Monkeys",
@@ -23,7 +23,7 @@
     "shortDescription": "Issue-to-PR workflow with quality gates, for any stack.",
     "longDescription": "Takes a ticket (Jira / Linear / GitHub Issues / Azure) from plan-approval through implementation, adaptive tests/coverage, security and accessibility review, to an opened pull request. Stack-agnostic. The issue tracker and PR host are configured per repo; connect the matching MCP (e.g. Atlassian for Jira, Linear) to let the kit read tickets.",
     "developerName": "The Agile Monkeys",
-    "category": "Engineering",
+    "category": "Developer Tools",
     "capabilities": [
       "Read",
       "Write"

--- a/plugins/fullstack-dev-kit/plugin.json
+++ b/plugins/fullstack-dev-kit/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "fullstack-dev-kit",
-  "version": "0.19.4",
+  "version": "0.19.5",
   "description": "Issue-to-PR workflow for any tech stack: fetch stories from Jira/Linear/GitHub/Azure and Figma designs, plan-approval gate, adaptive quality + coverage gates, e2e generation, PR creation and review.",
   "author": {
     "name": "The Agile Monkeys",
@@ -25,7 +25,7 @@
         "shortDescription": "Issue-to-PR workflow with quality gates, for any stack.",
         "longDescription": "Takes a ticket (Jira / Linear / GitHub Issues / Azure) from plan-approval through implementation, adaptive tests/coverage, security and accessibility review, to an opened pull request. Stack-agnostic. The issue tracker and PR host are configured per repo; connect the matching MCP (e.g. Atlassian for Jira, Linear) to let the kit read tickets.",
         "developerName": "The Agile Monkeys",
-        "category": "Engineering",
+        "category": "Developer Tools",
         "capabilities": [
           "Read",
           "Write"


### PR DESCRIPTION
OpenAI's plugin uploader rejects the `Engineering` category. Changed `interface.category` to **`Developer Tools`** (valid in the portal enum). The build mirrors it into the portable `plugin.json`; validator passes.

- Bumped kit version to **0.19.5** (propagates to installed marketplaces).
- CHANGELOG updated.

Non-blocking uploader warnings (screenshots dropped from ZIP; manifest normalized to Codex format) are expected — screenshots are added later via the portal UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)