### PR TITLE
fix(build): fail validation when the generated plugin bundle drifts from canonical sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ The `version` in `.claude-plugin/plugin.json` is what reaches installed clients 
 a release is only "live" for users once that is bumped and published.
 
 ## [Unreleased]
+### Fixed
+- **Bundle drift is now caught by validation.** `plugins/fullstack-dev-kit/{skills,instructions}/`
+  are generated copies, but `validate-codex-plugin.mjs` only checked that referenced files
+  *existed* — editing a stack profile and skipping the build shipped the old text to Codex,
+  Cursor and Copilot while validation still passed. The validator now compares every copy
+  against its source (and reports bundle files no source produces); builder and validator
+  share one mapping in `scripts/lib/bundle-sources.mjs` so they cannot disagree. Covered by
+  `scripts/validate-codex-plugin.test.mjs` (`node --test`). Tooling only — no plugin version bump.
 
 ## [0.19.5] - 2026-08-17
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,9 +48,21 @@ The kit ships baseline "iteration zero" profiles for common stacks in [`instruct
 
 1. Add or edit `instructions/stacks/<id>.md` following the format in [`instructions/stacks/README.md`](instructions/stacks/README.md): detection signals, commands (incl. test-with-coverage → report path + format), e2e framework, conventions and prerequisites.
 2. Add the detection signal to the table in `skills/dev-kit-setup/SKILL.md` if the stack is new.
-3. That's it — skills pick the profile up automatically via `stacks` in `.claude/dev-kit.json`. No code to touch (the skills are prompts).
+3. Run `node scripts/build-codex-plugin.mjs` and commit the result. `instructions/` and `skills/` are copied into `plugins/fullstack-dev-kit/` for Codex and the portable clients, so an edit that skips this ships the old text to them. `node scripts/validate-codex-plugin.mjs` fails if the copies are stale.
+4. That's it — skills pick the profile up automatically via `stacks` in `.claude/dev-kit.json`. No prompt or agent rewiring needed (the skills are prompts).
 
 ## Testing your changes locally
+
+Before pushing, rebuild the bundle and run the checks (no dependencies, no build step):
+
+```bash
+node scripts/build-codex-plugin.mjs   # refresh plugins/fullstack-dev-kit/ from the sources
+node scripts/validate-codex-plugin.mjs
+node --test                            # scripts/*.test.mjs
+git diff --exit-code                   # a dirty tree here means the bundle was not committed
+```
+
+Then exercise it in a real session:
 
 ```bash
 claude plugin marketplace add /path/to/your/clone

--- a/instructions/stacks/README.md
+++ b/instructions/stacks/README.md
@@ -47,7 +47,9 @@ Layout, test naming, mocking style, prerequisites (e.g. a coverage driver), and 
 
 ## Contributing a stack (or improving one)
 
-Add or edit one file here — nothing else is required for the kit to pick it up.
+Add or edit one file here, then run `node scripts/build-codex-plugin.mjs` and commit
+the result — this folder is copied into `plugins/fullstack-dev-kit/instructions/` for
+Codex and the portable clients, and only the copy reaches them.
 Prefer the mainstream toolchain for the stack, note prerequisites (e.g. PHP needs
 Xdebug/PCOV for coverage), and keep it to what the kit actually needs: how to run
 tests, get coverage, run e2e, and the conventions a reviewer would expect. See the

--- a/plugins/fullstack-dev-kit/instructions/stacks/README.md
+++ b/plugins/fullstack-dev-kit/instructions/stacks/README.md
@@ -47,7 +47,9 @@ Layout, test naming, mocking style, prerequisites (e.g. a coverage driver), and 
 
 ## Contributing a stack (or improving one)
 
-Add or edit one file here — nothing else is required for the kit to pick it up.
+Add or edit one file here, then run `node scripts/build-codex-plugin.mjs` and commit
+the result — this folder is copied into `plugins/fullstack-dev-kit/instructions/` for
+Codex and the portable clients, and only the copy reaches them.
 Prefer the mainstream toolchain for the stack, note prerequisites (e.g. PHP needs
 Xdebug/PCOV for coverage), and keep it to what the kit actually needs: how to run
 tests, get coverage, run e2e, and the conventions a reviewer would expect. See the

--- a/scripts/build-codex-plugin.mjs
+++ b/scripts/build-codex-plugin.mjs
@@ -12,47 +12,35 @@
  *
  *   node scripts/build-codex-plugin.mjs
  */
-import { readFileSync, writeFileSync, rmSync, mkdirSync, cpSync, readdirSync, existsSync } from 'node:fs';
+import { readFileSync, writeFileSync, rmSync, mkdirSync, cpSync, existsSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { spawnSync } from 'node:child_process';
+import { SKILL_SOURCES, TREE_SOURCES, skillDirs } from './lib/bundle-sources.mjs';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
-const SRC_SKILLS = join(ROOT, 'skills');
-const SRC_INSTR = join(ROOT, 'instructions');
 const PLUGIN = join(ROOT, 'plugins', 'fullstack-dev-kit');
 const DST_SKILLS = join(PLUGIN, 'skills');
 const DST_INSTR = join(PLUGIN, 'instructions');
 
-// 1. Resync skills (canonical top-level skills/ → plugin/skills/).
+// 1. Resync every mapped tree from lib/bundle-sources.mjs. The map is shared with the
+// validator, so a source added here is a source the validator checks for staleness.
+// `skills/` ships everywhere; `codex/skills/` is bundle-only (the work-story playbook
+// for hosts with no orchestrator subagent). instructions/ has to travel too, or a
+// native Codex install cannot run the kit's own security/testing/stack rules.
 rmSync(DST_SKILLS, { recursive: true, force: true });
 mkdirSync(DST_SKILLS, { recursive: true });
 let n = 0;
-for (const name of readdirSync(SRC_SKILLS)) {
-  if (!existsSync(join(SRC_SKILLS, name, 'SKILL.md'))) continue;
-  cpSync(join(SRC_SKILLS, name), join(DST_SKILLS, name), { recursive: true });
-  n++;
-}
-
-// 1a. Bundle-only skills (codex/skills/): shipped to the plugin (Codex + portable
-// clients like Cursor/Copilot) but NOT to the Claude Code plugin. This is where the
-// `work-story` orchestration playbook lives — hosts without an orchestrator subagent
-// follow it directly, whereas Claude Code uses its /work-story command + coding-agent.
-const SRC_BUNDLE_SKILLS = join(ROOT, 'codex', 'skills');
-if (existsSync(SRC_BUNDLE_SKILLS)) {
-  for (const name of readdirSync(SRC_BUNDLE_SKILLS)) {
-    if (!existsSync(join(SRC_BUNDLE_SKILLS, name, 'SKILL.md'))) continue;
-    cpSync(join(SRC_BUNDLE_SKILLS, name), join(DST_SKILLS, name), { recursive: true });
+for (const { src, dst } of SKILL_SOURCES) {
+  for (const name of skillDirs(ROOT, src)) {
+    cpSync(join(ROOT, src, name), join(ROOT, dst, name), { recursive: true });
     n++;
   }
 }
-
-// 1b. Resync the instructions the skills reference (secure-coding, testing-standards,
-// stacks/…). Without these the bundle isn't self-contained — a native Codex install
-// can't run the kit's own security/testing/stack rules. Their relative paths
-// (`instructions/…`) resolve from the plugin root, same as from the repo root.
-rmSync(DST_INSTR, { recursive: true, force: true });
-if (existsSync(SRC_INSTR)) cpSync(SRC_INSTR, DST_INSTR, { recursive: true });
+for (const { src, dst } of TREE_SOURCES) {
+  rmSync(join(ROOT, dst), { recursive: true, force: true });
+  if (existsSync(join(ROOT, src))) cpSync(join(ROOT, src), join(ROOT, dst), { recursive: true });
+}
 
 // 2. Keep the Codex plugin version aligned with the kit version.
 const kitVersion = JSON.parse(readFileSync(join(ROOT, '.claude-plugin', 'plugin.json'), 'utf8')).version;

--- a/scripts/lib/bundle-sources.mjs
+++ b/scripts/lib/bundle-sources.mjs
@@ -1,0 +1,93 @@
+/*
+ * bundle-sources — the one description of what the Codex/portable bundle is copied from.
+ *
+ * The builder copies these trees into plugins/fullstack-dev-kit/; the validator checks
+ * the copies still match. Both import this module so they cannot disagree: a mapping
+ * added for the builder is a mapping the validator enforces, with no second edit.
+ */
+import { readdirSync, existsSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+export const PLUGIN_DIR = join('plugins', 'fullstack-dev-kit');
+
+/*
+ * Skill collections. `skills/` ships to every host; `codex/skills/` is bundle-only
+ * (hosts without an orchestrator subagent follow the playbook directly), which is why
+ * a skill present in the bundle but absent from `skills/` is not automatically stale.
+ */
+export const SKILL_SOURCES = [
+  { src: 'skills', dst: join(PLUGIN_DIR, 'skills'), bundleOnly: false },
+  { src: join('codex', 'skills'), dst: join(PLUGIN_DIR, 'skills'), bundleOnly: true },
+];
+
+/* Whole trees copied verbatim. Skills reference these by relative path, so the bundle
+ * is only self-contained if the copy is current, not merely present. */
+export const TREE_SOURCES = [{ src: 'instructions', dst: join(PLUGIN_DIR, 'instructions') }];
+
+/** Directories under `src` that are skills (have a SKILL.md). */
+export function skillDirs(root, src) {
+  const dir = join(root, src);
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir).filter((name) => existsSync(join(dir, name, 'SKILL.md')));
+}
+
+function walk(dir, acc = []) {
+  if (!existsSync(dir)) return acc;
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    if (statSync(p).isDirectory()) walk(p, acc);
+    else acc.push(p);
+  }
+  return acc;
+}
+
+/**
+ * Every file that must be byte-identical between a canonical source and the bundle,
+ * as { src, dst, label } absolute-path pairs.
+ */
+export function syncedFilePairs(root) {
+  const pairs = [];
+  for (const { src, dst } of SKILL_SOURCES) {
+    for (const name of skillDirs(root, src)) {
+      const from = join(root, src, name);
+      for (const file of walk(from)) {
+        pairs.push({
+          src: file,
+          dst: join(root, dst, name, relative(from, file)),
+          label: join(src, name, relative(from, file)),
+        });
+      }
+    }
+  }
+  for (const { src, dst } of TREE_SOURCES) {
+    const from = join(root, src);
+    for (const file of walk(from)) {
+      pairs.push({
+        src: file,
+        dst: join(root, dst, relative(from, file)),
+        label: join(src, relative(from, file)),
+      });
+    }
+  }
+  return pairs;
+}
+
+/**
+ * Files inside a mapped bundle tree that no canonical source produces — a skill or
+ * instruction deleted upstream leaves its copy behind until the next build.
+ */
+export function orphanedBundleFiles(root) {
+  const expected = new Set(syncedFilePairs(root).map((p) => p.dst));
+  const orphans = [];
+  for (const name of skillDirs(root, join(PLUGIN_DIR, 'skills'))) {
+    for (const file of walk(join(root, PLUGIN_DIR, 'skills', name))) {
+      if (!expected.has(file)) orphans.push(relative(root, file));
+    }
+  }
+  for (const { dst } of TREE_SOURCES) {
+    for (const file of walk(join(root, dst))) {
+      if (!expected.has(file)) orphans.push(relative(root, file));
+    }
+  }
+  return orphans;
+}

--- a/scripts/validate-codex-plugin.mjs
+++ b/scripts/validate-codex-plugin.mjs
@@ -14,8 +14,9 @@
  *   node scripts/validate-codex-plugin.mjs
  */
 import { readFileSync, existsSync, readdirSync } from 'node:fs';
-import { join, dirname } from 'node:path';
+import { join, dirname, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { syncedFilePairs, orphanedBundleFiles } from './lib/bundle-sources.mjs';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const PLUGIN = join(ROOT, 'plugins', 'fullstack-dev-kit');
@@ -93,9 +94,24 @@ if (existsSync(skillsDir)) {
   }
 }
 
+// 5. The bundle is a copy, so "present" is not the same as "current". Check 4 proves
+// every referenced instructions file exists; this proves the copies still match their
+// canonical sources, which is what makes editing a source without rebuilding a caught
+// mistake rather than a silently shipped stale file.
+const drifted = [];
+const missing = [];
+for (const { src, dst, label } of syncedFilePairs(ROOT)) {
+  if (!existsSync(dst)) { missing.push(label); continue; }
+  if (readFileSync(src).equals(readFileSync(dst))) continue;
+  drifted.push(label);
+}
+for (const label of missing) errs.push(`bundle is missing "${label}" — run build-codex-plugin.mjs`);
+for (const label of drifted) errs.push(`bundle copy of "${label}" differs from the source — run build-codex-plugin.mjs`);
+for (const orphan of orphanedBundleFiles(ROOT)) errs.push(`bundle still carries "${orphan}", which no source produces — run build-codex-plugin.mjs`);
+
 if (errs.length) {
   console.error('✗ Codex plugin validation failed:');
   for (const e of errs) console.error('  - ' + e);
   process.exit(1);
 }
-console.log('✓ Codex plugin bundle is valid (marketplace + manifest + self-contained instructions).');
+console.log('✓ Codex plugin bundle is valid (marketplace + manifest + self-contained, in-sync instructions).');

--- a/scripts/validate-codex-plugin.test.mjs
+++ b/scripts/validate-codex-plugin.test.mjs
@@ -1,0 +1,82 @@
+/*
+ * Tests for the bundle-sync guard. Zero-dep (node:test), so `node --test scripts/`
+ * runs them anywhere the kit already runs.
+ *
+ * These assert the property the guard exists for: the validator must fail when a
+ * canonical source and its bundled copy disagree. Editing a source without rebuilding
+ * is the documented contribution path for stack profiles, so it has to be caught here
+ * rather than by a reviewer noticing a stale file in the diff.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { readFileSync, writeFileSync, rmSync, mkdirSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { syncedFilePairs, orphanedBundleFiles } from './lib/bundle-sources.mjs';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const validate = () => spawnSync(process.execPath, [join(ROOT, 'scripts', 'validate-codex-plugin.mjs')], { encoding: 'utf8' });
+const build = () => spawnSync(process.execPath, [join(ROOT, 'scripts', 'build-codex-plugin.mjs')], { encoding: 'utf8' });
+
+const PROBE = join(ROOT, 'instructions', 'stacks', 'php.md');
+
+test('the committed bundle is in sync', () => {
+  const result = validate();
+  assert.equal(result.status, 0, `validator failed on a clean tree:\n${result.stderr}`);
+});
+
+test('editing a source without rebuilding fails validation', () => {
+  const original = readFileSync(PROBE, 'utf8');
+  try {
+    writeFileSync(PROBE, `${original}\n<!-- drift probe -->\n`);
+    const result = validate();
+    assert.equal(result.status, 1, 'validator passed while the bundle was stale');
+    assert.match(result.stderr, /differs from the source/);
+    assert.match(result.stderr, /instructions\/stacks\/php\.md/);
+  } finally {
+    writeFileSync(PROBE, original);
+  }
+  assert.equal(validate().status, 0, 'validator did not recover after restoring the source');
+});
+
+test('rebuilding after an edit clears the failure', () => {
+  const original = readFileSync(PROBE, 'utf8');
+  try {
+    writeFileSync(PROBE, `${original}\n<!-- drift probe -->\n`);
+    assert.equal(validate().status, 1);
+    assert.equal(build().status, 0, 'builder failed');
+    assert.equal(validate().status, 0, 'validator still failing after a rebuild');
+  } finally {
+    writeFileSync(PROBE, original);
+    build();
+  }
+});
+
+test('a file deleted upstream is reported instead of lingering in the bundle', () => {
+  const dir = join(ROOT, 'instructions', 'stacks');
+  const temp = join(dir, '__drift-probe.md');
+  try {
+    writeFileSync(temp, '# probe\n');
+    assert.equal(build().status, 0);
+    assert.equal(validate().status, 0, 'a newly built file should validate');
+    rmSync(temp);
+    const result = validate();
+    assert.equal(result.status, 1, 'deleting a source left the bundle copy unreported');
+    assert.match(result.stderr, /which no source produces/);
+  } finally {
+    if (existsSync(temp)) rmSync(temp);
+    build();
+  }
+});
+
+test('bundle-only skills are not treated as drift', () => {
+  // codex/skills/work-story ships to the bundle and has no counterpart under skills/.
+  const orphans = orphanedBundleFiles(ROOT);
+  assert.deepEqual(orphans, [], `unexpected orphans: ${orphans.join(', ')}`);
+  const pairs = syncedFilePairs(ROOT).map((p) => p.label);
+  assert.ok(
+    pairs.some((label) => label.startsWith(join('codex', 'skills', 'work-story'))),
+    'the bundle-only skill is not covered by the sync map',
+  );
+});


### PR DESCRIPTION
<!-- Thanks for contributing! Keep PRs small and single-concern. -->

## What & why

`plugins/fullstack-dev-kit/{skills,instructions}/` are generated copies of the top-level sources, but `validate-codex-plugin.mjs` only checked that the `instructions/…` files a skill references **exist** — never that they still **match**. Editing a stack profile and skipping the build therefore passed validation and shipped the old text to Codex, Cursor and Copilot while Claude Code got the new one.

On `main` (`88b19d1`, v0.19.5, Node v22.23.2):

```bash
printf '\n<!-- edit -->\n' >> instructions/stacks/php.md
node scripts/validate-codex-plugin.mjs   # ✓ valid … exit 0
diff instructions/stacks/php.md plugins/fullstack-dev-kit/instructions/stacks/php.md   # differ, exit 1
```

That is the documented contribution path — CONTRIBUTING's "Adding or improving a stack profile" step 3 said *"That's it … No code to touch"* — so following the docs exactly produced a stale bundle.

The validator now compares every copy with its source and also reports bundle files that no source produces (a profile deleted upstream used to leave its copy behind). Builder and validator read one mapping from `scripts/lib/bundle-sources.mjs`, so adding a source to the build is the same edit that puts it under the guard, and bundle-only skills (`codex/skills/`) stay exempt by construction rather than by a special case.

Closes #39.

## Type
- [x] Bug fix
- [ ] New/improved stack profile (`instructions/stacks/…`)
- [ ] New/improved adapter (tracker / PR host)
- [ ] Docs
- [ ] Other:

## On the version bump

I left `.claude-plugin/plugin.json` alone. Nothing users execute changes: `scripts/` never ships, and no skill references `instructions/stacks/README.md` — skills load the per-stack profiles (`instructions/stacks/<id>.md`) and the two instruction files, never the README — so the single user-visible byte change is that README's copy inside the bundle. Against that, `faee776` (`chore(codex): harden plugin packaging …`, v0.18.1) is close prior art and did bump. Say the word and I'll push the bump with the CHANGELOG entry moved under it.

## Verification

```bash
node scripts/build-codex-plugin.mjs && node scripts/validate-codex-plugin.mjs && node --test && git diff --exit-code
# exit 0 on the committed tree; node --test → 5/5
```

Beyond the suite, the before/after probe on the real repo:

| probe | `main` | this branch |
|---|---|---|
| edit `instructions/stacks/php.md`, don't rebuild | validator exit **0** (stale copy ships) | exit **1**, names the file |
| rebuild after that edit | — | exit 0 |
| delete a source, leave the copy | not detected | exit 1, `which no source produces` |
| `codex/skills/work-story` (bundle-only, no counterpart in `skills/`) | — | not flagged |

`node --test scripts/` (bare directory) fails on Node 22 with `MODULE_NOT_FOUND`; the docs use `node --test`.

## Checklist
- [x] Keeps the kit **stack-agnostic** (nothing client/company/project-specific; stack detail stays in profiles/consuming repo).
- [x] Doesn't weaken the quality gates or the telemetry privacy guarantees — it adds a gate; `telemetry/` and `hooks/` are untouched.
- [x] Docs updated in the same PR (CONTRIBUTING step 3 + a local pre-flight block, `instructions/stacks/README.md`, CHANGELOG under `[Unreleased]`).
- [x] If this touches `packages/` or `telemetry/`, I've flagged it for extra review — it does not.
- [ ] Version bumped in `.claude-plugin/plugin.json` — **not bumped; your call.** Reasoning in "On the version bump" above.
