### PR TITLE
fix(build): guard the generated manifests and stop tests mutating the tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,21 @@ a release is only "live" for users once that is bumped and published.
   against its source (and reports bundle files no source produces); builder and validator
   share one mapping in `scripts/lib/bundle-sources.mjs` so they cannot disagree. Covered by
   `scripts/validate-codex-plugin.test.mjs` (`node --test`). Tooling only — no plugin version bump.
+- **The generated manifests are under the same guard.** The portable root
+  `plugins/fullstack-dev-kit/plugin.json` is dual-emitted from `.codex-plugin/plugin.json`, but the
+  validator only checked it *structurally* — editing the Codex manifest and skipping the build left
+  the portable copy stale and validation still passed, the same bug class the tree guard was added
+  for. The derivation now lives in `scripts/lib/bundle-sources.mjs`, and the validator re-derives and
+  byte-compares, so "builder and validator cannot disagree" holds for the manifests too.
+- **A skill name in two collections fails loudly.** `skills/` and `codex/skills/` deliberately copy
+  into the same bundle directory; the same skill *name* in both was second-wins at build time and
+  then unfixable drift at validation. Both now report it and exit non-zero. No collision exists today.
+### Changed
+- Bundle-guard tests run against a disposable copy of the tree instead of editing
+  `instructions/stacks/php.md` in place. A run killed between the edit and its `finally` restore used
+  to leave the working tree dirty, which then failed both the in-sync test and CONTRIBUTING's
+  `git diff --exit-code` step on the next run.
+- Removed a dead `DST_INSTR` constant left by the `bundle-sources` refactor.
 
 ## [0.19.5] - 2026-08-17
 ### Fixed

--- a/scripts/build-codex-plugin.mjs
+++ b/scripts/build-codex-plugin.mjs
@@ -16,18 +16,34 @@ import { readFileSync, writeFileSync, rmSync, mkdirSync, cpSync, existsSync } fr
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { spawnSync } from 'node:child_process';
-import { SKILL_SOURCES, TREE_SOURCES, skillDirs } from './lib/bundle-sources.mjs';
+import {
+  SKILL_SOURCES,
+  TREE_SOURCES,
+  skillDirs,
+  skillNameCollisions,
+  portableManifestFrom,
+  serializeManifest,
+} from './lib/bundle-sources.mjs';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const PLUGIN = join(ROOT, 'plugins', 'fullstack-dev-kit');
 const DST_SKILLS = join(PLUGIN, 'skills');
-const DST_INSTR = join(PLUGIN, 'instructions');
 
 // 1. Resync every mapped tree from lib/bundle-sources.mjs. The map is shared with the
 // validator, so a source added here is a source the validator checks for staleness.
 // `skills/` ships everywhere; `codex/skills/` is bundle-only (the work-story playbook
 // for hosts with no orchestrator subagent). instructions/ has to travel too, or a
 // native Codex install cannot run the kit's own security/testing/stack rules.
+// Two collections share the bundle's skills/ dir on purpose; the same skill *name* in
+// both would be silently second-wins here and unfixable drift in the validator.
+const collisions = skillNameCollisions(ROOT);
+if (collisions.length) {
+  for (const { name, sources } of collisions) {
+    console.error(`skill "${name}" is defined in both ${sources[0]}/ and ${sources[1]}/ — they copy to the same place`);
+  }
+  process.exit(1);
+}
+
 rmSync(DST_SKILLS, { recursive: true, force: true });
 mkdirSync(DST_SKILLS, { recursive: true });
 let n = 0;
@@ -55,23 +71,11 @@ if (manifest.version !== kitVersion) {
 // Codex reads .codex-plugin/plugin.json (required — verified: Codex 0.147 errors
 // "missing plugin.json" without it); portable clients (Cursor, VS Code, Copilot, …)
 // read this root plugin.json. Generated from the Codex manifest = one source of truth.
-// The portable schema is closed and has no home for Codex's `interface`/`skills` keys,
-// so `skills` is dropped (skills are auto-discovered from skills/) and `interface`
-// rides under our reverse-DNS extensions namespace.
+// The derivation lives in lib/bundle-sources.mjs so the validator can re-derive it and
+// byte-compare — without that, editing the Codex manifest and skipping this build
+// leaves the portable copy stale and validation still passes.
 const cm = JSON.parse(readFileSync(manifestPath, 'utf8'));
-const portable = {
-  $schema: 'https://agent-plugins.org/schemas/1.0.0/plugin.schema.json',
-  name: cm.name,
-  version: cm.version,
-  description: cm.description,
-  author: cm.author,          // {name, url} object — valid under the portable schema
-  homepage: cm.homepage,
-  repository: cm.repository,
-  license: cm.license,
-  keywords: cm.keywords,
-  extensions: { 'com.theagilemonkeys.dev-kit': { interface: cm.interface } },
-};
-writeFileSync(join(PLUGIN, 'plugin.json'), JSON.stringify(portable, null, 2) + '\n');
+writeFileSync(join(PLUGIN, 'plugin.json'), serializeManifest(portableManifestFrom(cm)));
 
 console.log(`Codex plugin built: ${n} skills + instructions/ synced, version ${kitVersion} (native + portable manifests).`);
 

--- a/scripts/lib/bundle-sources.mjs
+++ b/scripts/lib/bundle-sources.mjs
@@ -24,6 +24,64 @@ export const SKILL_SOURCES = [
  * is only self-contained if the copy is current, not merely present. */
 export const TREE_SOURCES = [{ src: 'instructions', dst: join(PLUGIN_DIR, 'instructions') }];
 
+/*
+ * The manifest pair. Codex reads `.codex-plugin/plugin.json` from inside the bundle;
+ * portable clients (Cursor, VS Code, Copilot, …) read the bundle-root `plugin.json`,
+ * which is *generated* from it. Same rule as the trees above: the derivation lives here
+ * so the builder and the validator cannot disagree about what it should contain. Without
+ * this, editing the Codex manifest and skipping the build leaves the portable copy stale
+ * and validation still passes — the exact bug class the tree guard exists to prevent.
+ */
+export const CODEX_MANIFEST = join(PLUGIN_DIR, '.codex-plugin', 'plugin.json');
+export const PORTABLE_MANIFEST = join(PLUGIN_DIR, 'plugin.json');
+export const PORTABLE_SCHEMA = 'https://agent-plugins.org/schemas/1.0.0/plugin.schema.json';
+
+/*
+ * The portable Agent Plugins 1.0.0 manifest, derived from the Codex manifest. The
+ * portable schema is closed, so it has no home for Codex's `skills` (dropped — portable
+ * hosts auto-discover from skills/) or `interface` (rides under our reverse-DNS
+ * extensions namespace).
+ */
+export function portableManifestFrom(codex) {
+  return {
+    $schema: PORTABLE_SCHEMA,
+    name: codex.name,
+    version: codex.version,
+    description: codex.description,
+    author: codex.author,
+    homepage: codex.homepage,
+    repository: codex.repository,
+    license: codex.license,
+    keywords: codex.keywords,
+    extensions: { 'com.theagilemonkeys.dev-kit': { interface: codex.interface } },
+  };
+}
+
+/** Serialised exactly as the builder writes it, so a byte comparison is meaningful. */
+export function serializeManifest(manifest) {
+  return `${JSON.stringify(manifest, null, 2)}\n`;
+}
+
+/*
+ * Two skill collections deliberately share one destination (`skills/` and `codex/skills/`
+ * both land in the bundle's `skills/`). A skill *name* in both would make the build
+ * second-wins and the validator would then report drift with no way to fix it. Nothing
+ * collides today; this makes a future one fail at its cause instead.
+ */
+export function skillNameCollisions(root) {
+  const owner = new Map();
+  const collisions = [];
+  for (const { src, dst } of SKILL_SOURCES) {
+    for (const name of skillDirs(root, src)) {
+      const key = join(dst, name);
+      const previous = owner.get(key);
+      if (previous) collisions.push({ name, sources: [previous, src] });
+      else owner.set(key, src);
+    }
+  }
+  return collisions;
+}
+
 /** Directories under `src` that are skills (have a SKILL.md). */
 export function skillDirs(root, src) {
   const dir = join(root, src);

--- a/scripts/validate-codex-plugin.mjs
+++ b/scripts/validate-codex-plugin.mjs
@@ -16,7 +16,14 @@
 import { readFileSync, existsSync, readdirSync } from 'node:fs';
 import { join, dirname, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { syncedFilePairs, orphanedBundleFiles } from './lib/bundle-sources.mjs';
+import {
+  syncedFilePairs,
+  orphanedBundleFiles,
+  skillNameCollisions,
+  portableManifestFrom,
+  serializeManifest,
+  PORTABLE_SCHEMA,
+} from './lib/bundle-sources.mjs';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const PLUGIN = join(ROOT, 'plugins', 'fullstack-dev-kit');
@@ -66,11 +73,34 @@ if (!existsSync(portPath)) errs.push(`missing portable ${portPath} — run build
 else {
   let pm; try { pm = readJson(portPath); } catch (e) { errs.push(`portable plugin.json is not valid JSON: ${e.message}`); }
   if (pm) {
-    if (pm.$schema !== 'https://agent-plugins.org/schemas/1.0.0/plugin.schema.json') errs.push('portable plugin.json: $schema must be the Agent Plugins 1.0.0 const URI');
+    if (pm.$schema !== PORTABLE_SCHEMA) errs.push('portable plugin.json: $schema must be the Agent Plugins 1.0.0 const URI');
     if (!pm.name || !/^(?!.*(?:--|\.\.))[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$/.test(pm.name)) errs.push(`portable plugin.json: name "${pm.name}" fails the 1.0.0 pattern`);
     if (pm.author && typeof pm.author !== 'object') errs.push('portable plugin.json: author must be an object {name,email,url}');
     for (const bad of ['skills', 'interface']) if (bad in pm) errs.push(`portable plugin.json: "${bad}" is not allowed by the closed schema — put it under extensions instead`);
   }
+
+  // The portable manifest is *generated* from the Codex one. Structure alone cannot tell
+  // us it is current, so re-derive it and byte-compare — the same rule the skill and
+  // instruction trees are held to.
+  if (existsSync(manPath)) {
+    let expected;
+    try {
+      expected = serializeManifest(portableManifestFrom(readJson(manPath)));
+    } catch {
+      /* the Codex manifest is already reported as unreadable above */
+    }
+    if (expected !== undefined && readFileSync(portPath, 'utf8') !== expected) {
+      errs.push(
+        `portable ${relative(ROOT, portPath)} differs from the source it is generated from ` +
+          `(${relative(ROOT, manPath)}) — run build-codex-plugin.mjs`,
+      );
+    }
+  }
+}
+
+// 3b. Skill-name collisions across collections that share a destination.
+for (const { name, sources } of skillNameCollisions(ROOT)) {
+  errs.push(`skill "${name}" is defined in both ${sources[0]}/ and ${sources[1]}/ — they copy to the same place`);
 }
 
 // 4. Self-contained bundle + portable skill-name rules.

--- a/scripts/validate-codex-plugin.test.mjs
+++ b/scripts/validate-codex-plugin.test.mjs
@@ -1,82 +1,170 @@
 /*
- * Tests for the bundle-sync guard. Zero-dep (node:test), so `node --test scripts/`
- * runs them anywhere the kit already runs.
+ * Tests for the bundle-sync guard. Zero-dep (node:test), so `node --test` runs them
+ * anywhere the kit already runs.
  *
  * These assert the property the guard exists for: the validator must fail when a
- * canonical source and its bundled copy disagree. Editing a source without rebuilding
+ * canonical source and its generated copy disagree. Editing a source without rebuilding
  * is the documented contribution path for stack profiles, so it has to be caught here
  * rather than by a reviewer noticing a stale file in the diff.
+ *
+ * Every mutating test runs against a throwaway copy of the repo, never the working tree.
+ * A test that edited a tracked file and restored it in `finally` would still leave the
+ * tree dirty if the run were killed between the two — and a dirty tree then fails both
+ * the in-sync test below and CONTRIBUTING's `git diff --exit-code` step on the next run.
  */
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { readFileSync, writeFileSync, rmSync, mkdirSync, existsSync } from 'node:fs';
+import { readFileSync, writeFileSync, rmSync, mkdtempSync, cpSync, existsSync } from 'node:fs';
 import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
-import { syncedFilePairs, orphanedBundleFiles } from './lib/bundle-sources.mjs';
+import {
+  syncedFilePairs,
+  orphanedBundleFiles,
+  skillNameCollisions,
+  portableManifestFrom,
+  serializeManifest,
+  CODEX_MANIFEST,
+  PORTABLE_MANIFEST,
+} from './lib/bundle-sources.mjs';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
-const validate = () => spawnSync(process.execPath, [join(ROOT, 'scripts', 'validate-codex-plugin.mjs')], { encoding: 'utf8' });
-const build = () => spawnSync(process.execPath, [join(ROOT, 'scripts', 'build-codex-plugin.mjs')], { encoding: 'utf8' });
 
-const PROBE = join(ROOT, 'instructions', 'stacks', 'php.md');
+/* Everything the builder and validator read. Copied, so the real tree is never touched. */
+const TREES = ['scripts', 'skills', 'codex', 'instructions', 'plugins', '.claude-plugin', '.agents'];
+
+/** A disposable copy of the repo. Returns its path; the caller removes it. */
+function sandbox() {
+  const dir = mkdtempSync(join(tmpdir(), 'dev-kit-drift-'));
+  for (const tree of TREES) {
+    const from = join(ROOT, tree);
+    if (existsSync(from)) cpSync(from, join(dir, tree), { recursive: true });
+  }
+  return dir;
+}
+
+const run = (root, script) =>
+  spawnSync(process.execPath, [join(root, 'scripts', script)], { encoding: 'utf8', cwd: root });
+const validate = (root) => run(root, 'validate-codex-plugin.mjs');
+const build = (root) => run(root, 'build-codex-plugin.mjs');
+
+/**
+ * Run `fn(sandboxPath)` against a fresh copy, always cleaning up.
+ *
+ * The copy is asserted valid before the body runs. Without that, a tree missing from
+ * TREES would make the sandbox invalid for an unrelated reason and every "expect exit 1"
+ * assertion below would pass for the wrong one.
+ */
+function inSandbox(fn) {
+  const dir = sandbox();
+  try {
+    const clean = validate(dir);
+    assert.equal(clean.status, 0, `the sandbox copy is not a valid tree:\n${clean.stderr}`);
+    return fn(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+/** Validator output with separators normalised, so assertions hold on Windows too. */
+const posix = (text) => text.replaceAll('\\', '/');
 
 test('the committed bundle is in sync', () => {
-  const result = validate();
+  const result = validate(ROOT);
   assert.equal(result.status, 0, `validator failed on a clean tree:\n${result.stderr}`);
 });
 
 test('editing a source without rebuilding fails validation', () => {
-  const original = readFileSync(PROBE, 'utf8');
-  try {
-    writeFileSync(PROBE, `${original}\n<!-- drift probe -->\n`);
-    const result = validate();
+  inSandbox((dir) => {
+    const probe = join(dir, 'instructions', 'stacks', 'php.md');
+    writeFileSync(probe, `${readFileSync(probe, 'utf8')}\n<!-- drift probe -->\n`);
+    const result = validate(dir);
     assert.equal(result.status, 1, 'validator passed while the bundle was stale');
     assert.match(result.stderr, /differs from the source/);
-    assert.match(result.stderr, /instructions\/stacks\/php\.md/);
-  } finally {
-    writeFileSync(PROBE, original);
-  }
-  assert.equal(validate().status, 0, 'validator did not recover after restoring the source');
+    assert.match(posix(result.stderr), /instructions\/stacks\/php\.md/);
+  });
 });
 
 test('rebuilding after an edit clears the failure', () => {
-  const original = readFileSync(PROBE, 'utf8');
-  try {
-    writeFileSync(PROBE, `${original}\n<!-- drift probe -->\n`);
-    assert.equal(validate().status, 1);
-    assert.equal(build().status, 0, 'builder failed');
-    assert.equal(validate().status, 0, 'validator still failing after a rebuild');
-  } finally {
-    writeFileSync(PROBE, original);
-    build();
-  }
+  inSandbox((dir) => {
+    const probe = join(dir, 'instructions', 'stacks', 'php.md');
+    writeFileSync(probe, `${readFileSync(probe, 'utf8')}\n<!-- drift probe -->\n`);
+    assert.equal(validate(dir).status, 1);
+    assert.equal(build(dir).status, 0, 'builder failed');
+    assert.equal(validate(dir).status, 0, 'validator still failing after a rebuild');
+  });
 });
 
 test('a file deleted upstream is reported instead of lingering in the bundle', () => {
-  const dir = join(ROOT, 'instructions', 'stacks');
-  const temp = join(dir, '__drift-probe.md');
-  try {
+  inSandbox((dir) => {
+    const temp = join(dir, 'instructions', 'stacks', '__drift-probe.md');
     writeFileSync(temp, '# probe\n');
-    assert.equal(build().status, 0);
-    assert.equal(validate().status, 0, 'a newly built file should validate');
+    assert.equal(build(dir).status, 0);
+    assert.equal(validate(dir).status, 0, 'a newly built file should validate');
     rmSync(temp);
-    const result = validate();
+    const result = validate(dir);
     assert.equal(result.status, 1, 'deleting a source left the bundle copy unreported');
     assert.match(result.stderr, /which no source produces/);
-  } finally {
-    if (existsSync(temp)) rmSync(temp);
-    build();
-  }
+  });
+});
+
+test('editing the Codex manifest without rebuilding fails validation', () => {
+  // The portable root plugin.json is generated from the Codex one. Structural checks
+  // cannot tell it is stale, so the validator re-derives and byte-compares.
+  inSandbox((dir) => {
+    const codex = join(dir, CODEX_MANIFEST);
+    const manifest = JSON.parse(readFileSync(codex, 'utf8'));
+    manifest.description = `${manifest.description} (drift probe)`;
+    writeFileSync(codex, `${JSON.stringify(manifest, null, 2)}\n`);
+
+    const result = validate(dir);
+    assert.equal(result.status, 1, 'validator passed while the portable manifest was stale');
+    assert.match(result.stderr, /differs from the source it is generated from/);
+
+    assert.equal(build(dir).status, 0, 'builder failed');
+    assert.equal(validate(dir).status, 0, 'validator still failing after a rebuild');
+    const portable = JSON.parse(readFileSync(join(dir, PORTABLE_MANIFEST), 'utf8'));
+    assert.equal(portable.description, manifest.description, 'rebuild did not propagate the edit');
+  });
+});
+
+test('the generated manifest is exactly what the shared derivation produces', () => {
+  const codex = JSON.parse(readFileSync(join(ROOT, CODEX_MANIFEST), 'utf8'));
+  assert.equal(
+    readFileSync(join(ROOT, PORTABLE_MANIFEST), 'utf8'),
+    serializeManifest(portableManifestFrom(codex)),
+    'the committed portable manifest is not a byte-for-byte derivation of its source',
+  );
+});
+
+test('a skill name in two collections is rejected rather than silently overwritten', () => {
+  inSandbox((dir) => {
+    // codex/skills/ and skills/ both copy into the bundle's skills/; the same name in
+    // both is second-wins at build time and unfixable drift afterwards.
+    cpSync(join(dir, 'codex', 'skills', 'work-story'), join(dir, 'skills', 'work-story'), {
+      recursive: true,
+    });
+    assert.equal(skillNameCollisions(dir).length, 1, 'the collision was not detected');
+
+    const built = build(dir);
+    assert.equal(built.status, 1, 'builder proceeded despite a collision');
+    assert.match(built.stderr, /defined in both/);
+
+    const result = validate(dir);
+    assert.equal(result.status, 1, 'validator ignored the collision');
+    assert.match(result.stderr, /defined in both/);
+  });
 });
 
 test('bundle-only skills are not treated as drift', () => {
   // codex/skills/work-story ships to the bundle and has no counterpart under skills/.
   const orphans = orphanedBundleFiles(ROOT);
   assert.deepEqual(orphans, [], `unexpected orphans: ${orphans.join(', ')}`);
-  const pairs = syncedFilePairs(ROOT).map((p) => p.label);
+  const pairs = syncedFilePairs(ROOT).map((p) => posix(p.label));
   assert.ok(
-    pairs.some((label) => label.startsWith(join('codex', 'skills', 'work-story'))),
+    pairs.some((label) => label.startsWith('codex/skills/work-story')),
     'the bundle-only skill is not covered by the sync map',
   );
+  assert.deepEqual(skillNameCollisions(ROOT), [], 'the committed tree has a skill-name collision');
 });


### PR DESCRIPTION
<!-- Thanks for contributing! Keep PRs small and single-concern. -->

## What & why

Closes #41 — all four items.

The guard in #40 covers the skill and instruction trees but not the manifest pair, so its own headline claim (*builder and validator cannot disagree*) did not hold end to end. `plugins/fullstack-dev-kit/plugin.json` is dual-emitted from `.codex-plugin/plugin.json`, and the validator only checked it **structurally** — `$schema`, the name pattern, the forbidden keys. Structure cannot tell you a generated file is current.

Confirming your reproduction on `56cd315`:

| edit the Codex manifest's `description`, skip the build | validator |
|---|---|
| `56cd315` (current `main`) | **exit 0** — stale portable copy ships |
| this branch | **exit 1** — `portable … differs from the source it is generated from` |

The derivation moves into `scripts/lib/bundle-sources.mjs` as `portableManifestFrom()` + `serializeManifest()`. The builder writes *through* it; the validator re-derives from the source and byte-compares. Same rule the trees are held to, same shared-map reason it cannot drift.

The other three:

- **Collision (item 4).** `skillNameCollisions()` reports a skill name present in both `skills/` and `codex/skills/`. Both scripts now exit non-zero — the builder before it copies anything, so it fails at the cause rather than as unfixable drift afterwards.
- **Tests mutating the tree (item 2).** Each mutating test now runs against a `mkdtempSync()` copy. Nothing tracked is opened for writing at all, so a `SIGKILL` mid-run cannot leave the tree dirty and break the next run's in-sync test and `git diff --exit-code`.
- **Dead `DST_INSTR` (item 3).** Removed.

## Type
- [x] Bug fix
- [ ] New/improved stack profile (`instructions/stacks/…`)
- [ ] New/improved adapter (tracker / PR host)
- [ ] Docs
- [ ] Other:

## Verification

```console
$ node scripts/build-codex-plugin.mjs && node scripts/validate-codex-plugin.mjs
✓ Codex plugin bundle is valid …
$ node --test
# tests 8   # pass 8   # fail 0
$ git diff --exit-code
$ echo $?
0
```

Tests go 5 → 8: manifest drift, the committed manifest being a byte-exact derivation of its source, and the collision guard.

### Integrity checks on the tests themselves

Passing tests prove nothing until they fail without their fix, so I mutated each one out and checked that exactly the intended test died:

| mutation | result |
|---|---|
| validator stops byte-comparing the manifest | 7 pass / **1 fail** — *editing the Codex manifest without rebuilding* |
| collision guard removed from both scripts | 7 pass / **1 fail** — *a skill name in two collections* |
| builder stops using the shared derivation | 5 pass / **3 fail** |
| restored | 8 / 8 |

That pass also found a false-pass hole in my own tests, now closed: the sandbox copy is asserted **valid before** each test mutates it. Without that, a tree missing from the copy list would make the sandbox invalid for an unrelated reason and every *expect exit 1* assertion would pass for the wrong one. Proof it fires — dropping `.agents` from the copied trees turns 5 silent false passes into 5 loud failures.

Also checked, all clean: building twice is a no-op; a missing or malformed `.codex-plugin/plugin.json` produces one clear error rather than a crash or a confusing second one; bumping `.claude-plugin/plugin.json` without rebuilding is still caught by the existing version check and is not masked by the new one; and a fresh clone of this branch builds, validates and passes 8/8 with a clean tree.

One thing I noticed and deliberately did **not** sweep: the test assertions matched `/instructions\/stacks\/php\.md/` while the validator builds those labels with `path.join`, which is backslashed on Windows. I normalised separators in the assertions I touched, but the same assumption may exist elsewhere in the repo — out of scope here, happy to file it separately if useful.

## On the version bump

Not bumped, same reasoning as #40 and your call again: `scripts/` never ships, and the bundle is byte-identical after a rebuild (`git diff --exit-code` above), so nothing users install changes. Say the word and I'll push the bump with the CHANGELOG entry moved under it.

## Checklist
- [x] Keeps the kit **stack-agnostic** — tooling only, no stack or client specifics.
- [x] Doesn't weaken the quality gates or the telemetry privacy guarantees — it extends a gate; `telemetry/` and `hooks/` are untouched.
- [x] Docs updated in the same PR — CHANGELOG under `[Unreleased]`. No CONTRIBUTING change needed: the contributor-facing workflow is unchanged, only what validation catches.
- [x] If this touches `packages/` or `telemetry/`, I've flagged it for extra review — it does not.
- [ ] Version bumped in `.claude-plugin/plugin.json` — **not bumped; your call.** Reasoning above.
