### PR TITLE
fix(build): extend drift guard to generated manifests + tooling nits (#41)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ a release is only "live" for users once that is bumped and published.
   against its source (and reports bundle files no source produces); builder and validator
   share one mapping in `scripts/lib/bundle-sources.mjs` so they cannot disagree. Covered by
   `scripts/validate-codex-plugin.test.mjs` (`node --test`). Tooling only — no plugin version bump.
+- **Drift guard now covers the generated manifests too** (#41, follow-up to the above). The
+  portable root `plugin.json` is derived from `.codex-plugin/plugin.json`, but validation only
+  checked it structurally — editing the Codex manifest without rebuilding left a stale portable
+  manifest and still passed. The derive transform now lives in `bundle-sources.mjs`, and the
+  validator re-derives + byte-compares it, so "builder and validator cannot disagree" holds for
+  the manifest pair end-to-end. Also: a `collidingSkillNames` guard (a skill name in both
+  `skills/` and `codex/skills/`), removal of a dead `DST_INSTR`, and the drift tests now run on a
+  throwaway `DEVKIT_ROOT` fixture instead of mutating a tracked file. Tooling only — no version bump.
 
 ## [0.19.5] - 2026-08-17
 ### Fixed

--- a/scripts/build-codex-plugin.mjs
+++ b/scripts/build-codex-plugin.mjs
@@ -13,15 +13,18 @@
  *   node scripts/build-codex-plugin.mjs
  */
 import { readFileSync, writeFileSync, rmSync, mkdirSync, cpSync, existsSync } from 'node:fs';
-import { join, dirname } from 'node:path';
+import { join, dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { spawnSync } from 'node:child_process';
-import { SKILL_SOURCES, TREE_SOURCES, skillDirs } from './lib/bundle-sources.mjs';
+import { SKILL_SOURCES, TREE_SOURCES, skillDirs, derivePortableManifest, serializeManifest } from './lib/bundle-sources.mjs';
 
-const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+// DEVKIT_ROOT lets the test suite build against a throwaway fixture tree instead of the
+// real repo; unset, it resolves to the repo root as before. SCRIPT_DIR always points at
+// the real scripts/ (where the validator lives), independent of which tree we build.
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const ROOT = process.env.DEVKIT_ROOT ? resolve(process.env.DEVKIT_ROOT) : join(SCRIPT_DIR, '..');
 const PLUGIN = join(ROOT, 'plugins', 'fullstack-dev-kit');
 const DST_SKILLS = join(PLUGIN, 'skills');
-const DST_INSTR = join(PLUGIN, 'instructions');
 
 // 1. Resync every mapped tree from lib/bundle-sources.mjs. The map is shared with the
 // validator, so a source added here is a source the validator checks for staleness.
@@ -54,27 +57,13 @@ if (manifest.version !== kitVersion) {
 // 3. Dual-emit the PORTABLE Agent Plugins 1.0.0 manifest at the plugin root.
 // Codex reads .codex-plugin/plugin.json (required — verified: Codex 0.147 errors
 // "missing plugin.json" without it); portable clients (Cursor, VS Code, Copilot, …)
-// read this root plugin.json. Generated from the Codex manifest = one source of truth.
-// The portable schema is closed and has no home for Codex's `interface`/`skills` keys,
-// so `skills` is dropped (skills are auto-discovered from skills/) and `interface`
-// rides under our reverse-DNS extensions namespace.
+// read this root plugin.json. The transform lives in lib/bundle-sources.mjs so the
+// validator can re-derive it and catch a stale portable manifest (drift guard).
 const cm = JSON.parse(readFileSync(manifestPath, 'utf8'));
-const portable = {
-  $schema: 'https://agent-plugins.org/schemas/1.0.0/plugin.schema.json',
-  name: cm.name,
-  version: cm.version,
-  description: cm.description,
-  author: cm.author,          // {name, url} object — valid under the portable schema
-  homepage: cm.homepage,
-  repository: cm.repository,
-  license: cm.license,
-  keywords: cm.keywords,
-  extensions: { 'com.theagilemonkeys.dev-kit': { interface: cm.interface } },
-};
-writeFileSync(join(PLUGIN, 'plugin.json'), JSON.stringify(portable, null, 2) + '\n');
+writeFileSync(join(PLUGIN, 'plugin.json'), serializeManifest(derivePortableManifest(cm)));
 
 console.log(`Codex plugin built: ${n} skills + instructions/ synced, version ${kitVersion} (native + portable manifests).`);
 
 // Validate the freshly-built bundle (structure, enums, self-contained instructions).
-const v = spawnSync(process.execPath, [join(ROOT, 'scripts', 'validate-codex-plugin.mjs')], { stdio: 'inherit' });
+const v = spawnSync(process.execPath, [join(SCRIPT_DIR, 'validate-codex-plugin.mjs')], { stdio: 'inherit' });
 if (v.status !== 0) process.exit(v.status || 1);

--- a/scripts/lib/bundle-sources.mjs
+++ b/scripts/lib/bundle-sources.mjs
@@ -5,7 +5,7 @@
  * the copies still match. Both import this module so they cannot disagree: a mapping
  * added for the builder is a mapping the validator enforces, with no second edit.
  */
-import { readdirSync, existsSync, statSync } from 'node:fs';
+import { readdirSync, readFileSync, existsSync, statSync } from 'node:fs';
 import { join, relative } from 'node:path';
 
 export const PLUGIN_DIR = join('plugins', 'fullstack-dev-kit');
@@ -90,4 +90,78 @@ export function orphanedBundleFiles(root) {
     }
   }
   return orphans;
+}
+
+/** Byte-level drift of every synced source→bundle file pair. */
+export function syncedFileDrift(root) {
+  const missing = [];
+  const drifted = [];
+  for (const { src, dst, label } of syncedFilePairs(root)) {
+    if (!existsSync(dst)) { missing.push(label); continue; }
+    if (readFileSync(src).equals(readFileSync(dst))) continue;
+    drifted.push(label);
+  }
+  return { missing, drifted };
+}
+
+/**
+ * Skill names that appear in more than one skill source. Both SKILL_SOURCES copy into
+ * the same bundle `skills/` dir, so a shared name is a copy-into-same-dst collision:
+ * the build is second-wins and the validator then reports drift no rebuild can fix.
+ * There is none today (only `work-story` under codex/skills/), so this is a guardrail.
+ */
+export function collidingSkillNames(root) {
+  const counts = new Map();
+  for (const { src } of SKILL_SOURCES) {
+    for (const name of skillDirs(root, src)) counts.set(name, (counts.get(name) || 0) + 1);
+  }
+  return [...counts.entries()].filter(([, count]) => count > 1).map(([name]) => name);
+}
+
+// The portable Agent Plugins 1.0.0 manifest is a pure transform of the Codex manifest.
+// Keeping that transform here (not inline in the builder) lets the validator re-derive
+// the expected portable manifest and byte-compare it to the committed one — closing the
+// drift class the tree guard already closes, for the generated manifest pair.
+export const PORTABLE_SCHEMA = 'https://agent-plugins.org/schemas/1.0.0/plugin.schema.json';
+export const PORTABLE_EXTENSION = 'com.theagilemonkeys.dev-kit';
+
+/**
+ * Derive the portable root plugin.json from the Codex `.codex-plugin/plugin.json`.
+ * The portable schema is closed: `skills` has no home (skills are auto-discovered) and
+ * `interface` rides under our reverse-DNS extensions namespace.
+ */
+export function derivePortableManifest(cm) {
+  return {
+    $schema: PORTABLE_SCHEMA,
+    name: cm.name,
+    version: cm.version,
+    description: cm.description,
+    author: cm.author,
+    homepage: cm.homepage,
+    repository: cm.repository,
+    license: cm.license,
+    keywords: cm.keywords,
+    extensions: { [PORTABLE_EXTENSION]: { interface: cm.interface } },
+  };
+}
+
+/** Exact on-disk serialization the builder writes (so byte-compare is meaningful). */
+export function serializeManifest(obj) {
+  return JSON.stringify(obj, null, 2) + '\n';
+}
+
+/**
+ * Whether the committed portable plugin.json still matches what the current Codex
+ * manifest would generate. Returns null when in sync (or when either manifest is
+ * absent — that is the structural checks' job), else a human-readable reason.
+ */
+export function portableManifestDrift(root) {
+  const codexPath = join(root, PLUGIN_DIR, '.codex-plugin', 'plugin.json');
+  const portPath = join(root, PLUGIN_DIR, 'plugin.json');
+  if (!existsSync(codexPath) || !existsSync(portPath)) return null;
+  let cm;
+  try { cm = JSON.parse(readFileSync(codexPath, 'utf8')); } catch { return null; }
+  const expected = serializeManifest(derivePortableManifest(cm));
+  if (readFileSync(portPath, 'utf8') === expected) return null;
+  return 'portable plugin.json differs from what .codex-plugin/plugin.json would generate';
 }

--- a/scripts/validate-codex-plugin.mjs
+++ b/scripts/validate-codex-plugin.mjs
@@ -14,11 +14,13 @@
  *   node scripts/validate-codex-plugin.mjs
  */
 import { readFileSync, existsSync, readdirSync } from 'node:fs';
-import { join, dirname, relative } from 'node:path';
+import { join, dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { syncedFilePairs, orphanedBundleFiles } from './lib/bundle-sources.mjs';
+import { syncedFileDrift, orphanedBundleFiles, collidingSkillNames, portableManifestDrift } from './lib/bundle-sources.mjs';
 
-const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+// DEVKIT_ROOT lets the test suite validate a throwaway fixture tree; unset, it resolves
+// to the repo root as before.
+const ROOT = process.env.DEVKIT_ROOT ? resolve(process.env.DEVKIT_ROOT) : join(dirname(fileURLToPath(import.meta.url)), '..');
 const PLUGIN = join(ROOT, 'plugins', 'fullstack-dev-kit');
 const errs = [];
 const readJson = (p) => JSON.parse(readFileSync(p, 'utf8'));
@@ -96,18 +98,16 @@ if (existsSync(skillsDir)) {
 
 // 5. The bundle is a copy, so "present" is not the same as "current". Check 4 proves
 // every referenced instructions file exists; this proves the copies still match their
-// canonical sources, which is what makes editing a source without rebuilding a caught
-// mistake rather than a silently shipped stale file.
-const drifted = [];
-const missing = [];
-for (const { src, dst, label } of syncedFilePairs(ROOT)) {
-  if (!existsSync(dst)) { missing.push(label); continue; }
-  if (readFileSync(src).equals(readFileSync(dst))) continue;
-  drifted.push(label);
-}
+// canonical sources — and that the generated portable manifest still matches the Codex
+// manifest it is derived from — so editing a source (or the manifest) without rebuilding
+// is a caught mistake rather than a silently shipped stale file.
+const { missing, drifted } = syncedFileDrift(ROOT);
 for (const label of missing) errs.push(`bundle is missing "${label}" — run build-codex-plugin.mjs`);
 for (const label of drifted) errs.push(`bundle copy of "${label}" differs from the source — run build-codex-plugin.mjs`);
 for (const orphan of orphanedBundleFiles(ROOT)) errs.push(`bundle still carries "${orphan}", which no source produces — run build-codex-plugin.mjs`);
+const manifestDrift = portableManifestDrift(ROOT);
+if (manifestDrift) errs.push(`${manifestDrift} — run build-codex-plugin.mjs`);
+for (const name of collidingSkillNames(ROOT)) errs.push(`skill "${name}" exists in more than one skill source — names must be unique across skills/ and codex/skills/`);
 
 if (errs.length) {
   console.error('✗ Codex plugin validation failed:');

--- a/scripts/validate-codex-plugin.mjs
+++ b/scripts/validate-codex-plugin.mjs
@@ -101,13 +101,19 @@ if (existsSync(skillsDir)) {
 // canonical sources — and that the generated portable manifest still matches the Codex
 // manifest it is derived from — so editing a source (or the manifest) without rebuilding
 // is a caught mistake rather than a silently shipped stale file.
-const { missing, drifted } = syncedFileDrift(ROOT);
-for (const label of missing) errs.push(`bundle is missing "${label}" — run build-codex-plugin.mjs`);
-for (const label of drifted) errs.push(`bundle copy of "${label}" differs from the source — run build-codex-plugin.mjs`);
-for (const orphan of orphanedBundleFiles(ROOT)) errs.push(`bundle still carries "${orphan}", which no source produces — run build-codex-plugin.mjs`);
+// A name collision makes the "losing" copy read as drift, so the per-file drift/orphan
+// lines would be derivative noise — lead with the cause and suppress them when a
+// collision is present. Manifest drift is orthogonal, so it is always checked.
+const collisions = collidingSkillNames(ROOT);
+for (const name of collisions) errs.push(`skill "${name}" exists in more than one skill source — names must be unique across skills/ and codex/skills/`);
+if (!collisions.length) {
+  const { missing, drifted } = syncedFileDrift(ROOT);
+  for (const label of missing) errs.push(`bundle is missing "${label}" — run build-codex-plugin.mjs`);
+  for (const label of drifted) errs.push(`bundle copy of "${label}" differs from the source — run build-codex-plugin.mjs`);
+  for (const orphan of orphanedBundleFiles(ROOT)) errs.push(`bundle still carries "${orphan}", which no source produces — run build-codex-plugin.mjs`);
+}
 const manifestDrift = portableManifestDrift(ROOT);
 if (manifestDrift) errs.push(`${manifestDrift} — run build-codex-plugin.mjs`);
-for (const name of collidingSkillNames(ROOT)) errs.push(`skill "${name}" exists in more than one skill source — names must be unique across skills/ and codex/skills/`);
 
 if (errs.length) {
   console.error('✗ Codex plugin validation failed:');

--- a/scripts/validate-codex-plugin.test.mjs
+++ b/scripts/validate-codex-plugin.test.mjs
@@ -65,7 +65,10 @@ function makeFixture() {
 function builtFixture() {
   const root = makeFixture();
   const r = build(root);
-  assert.equal(r.status, 0, `builder failed on a fresh fixture:\n${r.stderr}`);
+  if (r.status !== 0) {
+    rmSync(root, { recursive: true, force: true }); // don't leak the tmp dir on the failure path
+    assert.fail(`builder failed on a fresh fixture:\n${r.stderr}`);
+  }
   return root;
 }
 
@@ -142,6 +145,8 @@ test('a skill name in two sources is reported as a collision', () => {
     const r = validate(root);
     assert.equal(r.status, 1, 'a colliding skill name passed validation');
     assert.match(r.stderr, /exists in more than one skill source/);
+    // The collision is the root cause; the derivative per-file drift line is suppressed.
+    assert.doesNotMatch(r.stderr, /differs from the source/);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/scripts/validate-codex-plugin.test.mjs
+++ b/scripts/validate-codex-plugin.test.mjs
@@ -1,82 +1,148 @@
 /*
- * Tests for the bundle-sync guard. Zero-dep (node:test), so `node --test scripts/`
- * runs them anywhere the kit already runs.
+ * Tests for the bundle-sync guard. Zero-dep (node:test), so `node --test` runs them
+ * anywhere the kit already runs.
  *
  * These assert the property the guard exists for: the validator must fail when a
- * canonical source and its bundled copy disagree. Editing a source without rebuilding
- * is the documented contribution path for stack profiles, so it has to be caught here
- * rather than by a reviewer noticing a stale file in the diff.
+ * canonical source (a skill/instructions file OR the Codex manifest) and its generated
+ * bundle copy disagree. Everything runs against a throwaway fixture tree under the OS
+ * tmpdir via DEVKIT_ROOT — no tracked file is ever mutated, so a hard-killed run cannot
+ * leave the repo dirty (the failure mode the previous in-place approach had).
  */
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { readFileSync, writeFileSync, rmSync, mkdirSync, existsSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, appendFileSync, rmSync } from 'node:fs';
 import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
-import { syncedFilePairs, orphanedBundleFiles } from './lib/bundle-sources.mjs';
+import { orphanedBundleFiles, collidingSkillNames, portableManifestDrift } from './lib/bundle-sources.mjs';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
-const validate = () => spawnSync(process.execPath, [join(ROOT, 'scripts', 'validate-codex-plugin.mjs')], { encoding: 'utf8' });
-const build = () => spawnSync(process.execPath, [join(ROOT, 'scripts', 'build-codex-plugin.mjs')], { encoding: 'utf8' });
+const BUILD = join(ROOT, 'scripts', 'build-codex-plugin.mjs');
+const VALIDATE = join(ROOT, 'scripts', 'validate-codex-plugin.mjs');
 
-const PROBE = join(ROOT, 'instructions', 'stacks', 'php.md');
+const run = (script, root) =>
+  spawnSync(process.execPath, [script], { encoding: 'utf8', env: { ...process.env, DEVKIT_ROOT: root } });
+const build = (root) => run(BUILD, root);
+const validate = (root) => run(VALIDATE, root);
 
-test('the committed bundle is in sync', () => {
-  const result = validate();
-  assert.equal(result.status, 0, `validator failed on a clean tree:\n${result.stderr}`);
+/** Write a minimal but fully-valid source tree; the caller then runs the builder on it. */
+function makeFixture() {
+  const root = mkdtempSync(join(tmpdir(), 'devkit-bundle-'));
+  const write = (rel, body) => {
+    mkdirSync(dirname(join(root, rel)), { recursive: true });
+    writeFileSync(join(root, rel), body);
+  };
+  write('.claude-plugin/plugin.json', JSON.stringify({ name: 'fullstack-dev-kit', version: '9.9.9' }, null, 2) + '\n');
+  write('.agents/plugins/marketplace.json', JSON.stringify({
+    name: 'claude-dev-kit',
+    plugins: [{
+      name: 'fullstack-dev-kit',
+      source: { source: 'local', path: './plugins/fullstack-dev-kit' },
+      policy: { installation: 'AVAILABLE', authentication: 'ON_USE' },
+    }],
+  }, null, 2) + '\n');
+  write('skills/demo/SKILL.md', '---\nname: demo\ndescription: A demo skill.\n---\nBody.\n');
+  write('codex/skills/play/SKILL.md', '---\nname: play\ndescription: A bundle-only skill.\n---\nPlaybook.\n');
+  write('instructions/secure-coding.md', 'Secure coding rules.\n');
+  write('instructions/stacks/node.md', 'Node profile.\n');
+  write('plugins/fullstack-dev-kit/.codex-plugin/plugin.json', JSON.stringify({
+    name: 'fullstack-dev-kit',
+    version: '9.9.9',
+    description: 'Fixture plugin.',
+    author: { name: 'The Agile Monkeys', url: 'https://example.test' },
+    homepage: 'https://example.test',
+    repository: 'https://example.test',
+    license: 'Apache-2.0',
+    keywords: ['fixture'],
+    skills: './skills/',
+    interface: { displayName: 'Fixture', category: 'Developer Tools' },
+  }, null, 2) + '\n');
+  return root;
+}
+
+/** A fixture with its bundle freshly built — the in-sync starting point for drift tests. */
+function builtFixture() {
+  const root = makeFixture();
+  const r = build(root);
+  assert.equal(r.status, 0, `builder failed on a fresh fixture:\n${r.stderr}`);
+  return root;
+}
+
+test('the committed bundle passes validation', () => {
+  // Read-only: runs against the real repo, mutates nothing.
+  const r = validate(ROOT);
+  assert.equal(r.status, 0, `validator failed on the committed tree:\n${r.stderr}`);
 });
 
-test('editing a source without rebuilding fails validation', () => {
-  const original = readFileSync(PROBE, 'utf8');
+test('a freshly built fixture is in sync', () => {
+  const root = builtFixture();
   try {
-    writeFileSync(PROBE, `${original}\n<!-- drift probe -->\n`);
-    const result = validate();
-    assert.equal(result.status, 1, 'validator passed while the bundle was stale');
-    assert.match(result.stderr, /differs from the source/);
-    assert.match(result.stderr, /instructions\/stacks\/php\.md/);
+    assert.equal(validate(root).status, 0);
+    assert.deepEqual(orphanedBundleFiles(root), []);
+    assert.deepEqual(collidingSkillNames(root), []);
+    assert.equal(portableManifestDrift(root), null);
   } finally {
-    writeFileSync(PROBE, original);
+    rmSync(root, { recursive: true, force: true });
   }
-  assert.equal(validate().status, 0, 'validator did not recover after restoring the source');
 });
 
-test('rebuilding after an edit clears the failure', () => {
-  const original = readFileSync(PROBE, 'utf8');
+test('editing an instructions source without rebuilding fails validation', () => {
+  const root = builtFixture();
   try {
-    writeFileSync(PROBE, `${original}\n<!-- drift probe -->\n`);
-    assert.equal(validate().status, 1);
-    assert.equal(build().status, 0, 'builder failed');
-    assert.equal(validate().status, 0, 'validator still failing after a rebuild');
+    appendFileSync(join(root, 'instructions', 'stacks', 'node.md'), '\n<!-- drift -->\n');
+    const r = validate(root);
+    assert.equal(r.status, 1, 'validator passed while the bundle was stale');
+    assert.match(r.stderr, /differs from the source/);
+    assert.match(r.stderr, /instructions[/\\]stacks[/\\]node\.md/);
+    assert.equal(build(root).status, 0);
+    assert.equal(validate(root).status, 0, 'rebuild did not clear the drift');
   } finally {
-    writeFileSync(PROBE, original);
-    build();
+    rmSync(root, { recursive: true, force: true });
   }
 });
 
-test('a file deleted upstream is reported instead of lingering in the bundle', () => {
-  const dir = join(ROOT, 'instructions', 'stacks');
-  const temp = join(dir, '__drift-probe.md');
+test('editing the Codex manifest without rebuilding fails validation (portable drift)', () => {
+  const root = builtFixture();
   try {
-    writeFileSync(temp, '# probe\n');
-    assert.equal(build().status, 0);
-    assert.equal(validate().status, 0, 'a newly built file should validate');
-    rmSync(temp);
-    const result = validate();
-    assert.equal(result.status, 1, 'deleting a source left the bundle copy unreported');
-    assert.match(result.stderr, /which no source produces/);
+    const cmPath = join(root, 'plugins', 'fullstack-dev-kit', '.codex-plugin', 'plugin.json');
+    const cm = JSON.parse(readFileSync(cmPath, 'utf8'));
+    cm.description = 'Edited without rebuilding.';
+    writeFileSync(cmPath, JSON.stringify(cm, null, 2) + '\n');
+    const r = validate(root);
+    assert.equal(r.status, 1, 'validator passed while the portable manifest was stale');
+    assert.match(r.stderr, /portable plugin\.json differs/);
+    assert.equal(build(root).status, 0);
+    assert.equal(validate(root).status, 0, 'rebuild did not clear the manifest drift');
   } finally {
-    if (existsSync(temp)) rmSync(temp);
-    build();
+    rmSync(root, { recursive: true, force: true });
   }
 });
 
-test('bundle-only skills are not treated as drift', () => {
-  // codex/skills/work-story ships to the bundle and has no counterpart under skills/.
-  const orphans = orphanedBundleFiles(ROOT);
-  assert.deepEqual(orphans, [], `unexpected orphans: ${orphans.join(', ')}`);
-  const pairs = syncedFilePairs(ROOT).map((p) => p.label);
-  assert.ok(
-    pairs.some((label) => label.startsWith(join('codex', 'skills', 'work-story'))),
-    'the bundle-only skill is not covered by the sync map',
-  );
+test('a source deleted upstream is reported instead of lingering in the bundle', () => {
+  const root = builtFixture();
+  try {
+    rmSync(join(root, 'instructions', 'stacks', 'node.md'));
+    const r = validate(root);
+    assert.equal(r.status, 1, 'deleting a source left the bundle copy unreported');
+    assert.match(r.stderr, /which no source produces/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('a skill name in two sources is reported as a collision', () => {
+  const root = makeFixture();
+  try {
+    // `demo` now exists under both skills/ and codex/skills/ → copy-into-same-dst collision.
+    mkdirSync(join(root, 'codex', 'skills', 'demo'), { recursive: true });
+    writeFileSync(join(root, 'codex', 'skills', 'demo', 'SKILL.md'), '---\nname: demo\ndescription: Dupe.\n---\nDupe.\n');
+    assert.deepEqual(collidingSkillNames(root), ['demo']);
+    build(root);
+    const r = validate(root);
+    assert.equal(r.status, 1, 'a colliding skill name passed validation');
+    assert.match(r.stderr, /exists in more than one skill source/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
Closes #41. Follow-up to #40, which closed the drift class for the `skills/` + `instructions/` trees but left it open for the generated manifests.

## The gap (item 1)
The portable root `plugin.json` is derived from `.codex-plugin/plugin.json`, but the validator only checked it **structurally** — never against its source. Editing the Codex manifest (e.g. `description`, `interface.category`) without rebuilding left a stale portable manifest and validation still exited 0. Confirmed empirically on `main`, and now on this branch:

```
# edit .codex-plugin/plugin.json description, don't rebuild
node scripts/validate-codex-plugin.mjs
# main:        ✓ valid, exit 0   (stale portable manifest ships)
# this branch: ✗ "portable plugin.json differs from what .codex-plugin/plugin.json would generate", exit 1
```

The portable-manifest transform now lives in `scripts/lib/bundle-sources.mjs` (`derivePortableManifest`), the builder emits it from there, and the validator **re-derives + byte-compares** it. So the PR #40 headline — *builder and validator cannot disagree* — now holds for the manifest pair end-to-end.

## Also in scope (items 2–4)
- **Item 4 — collision guard.** `collidingSkillNames`: a skill name in both `skills/` and `codex/skills/` copies into the same bundle `skills/` dir (second-wins) and then reads as unfixable drift. Now reported with a clear message instead.
- **Item 3 — dead code.** Removed the unused `DST_INSTR` (and a stray unused `relative` import in the validator).
- **Item 2 — test fragility.** The drift tests no longer mutate a tracked file (`instructions/stacks/php.md`) and lean on `finally`. They build/validate a throwaway fixture under the OS tmpdir via a new `DEVKIT_ROOT` override, so a SIGKILL/CI-timeout mid-run can't leave the repo dirty.

## Verification
```
node scripts/build-codex-plugin.mjs && node scripts/validate-codex-plugin.mjs && node --test && git diff --exit-code
# validator ✓ · node --test → 6/6 · tree clean (no plugins/ diff — the extracted transform is byte-identical)
```

Tooling only — `scripts/` never ship and no skill-referenced content changed, so no plugin version bump (same reasoning as #40).

🤖 Generated with [Claude Code](https://claude.com/claude-code)