### PR TITLE
chore(relay): make Vercel ignoreCommand robust to missing HEAD^

### DIFF
--- a/packages/telemetry-relay/vercel.json
+++ b/packages/telemetry-relay/vercel.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- :/packages/telemetry-relay",
+  "ignoreCommand": "git rev-parse --verify HEAD^ >/dev/null 2>&1 && git diff --quiet HEAD^ HEAD -- :/packages/telemetry-relay",
   "functions": {
     "api/ingest.js": {
       "includeFiles": "contract.v1.json"


### PR DESCRIPTION
The relay build is gated by an `ignoreCommand` so a push that doesn't touch `packages/telemetry-relay` cancels instead of redeploying. The old command (`git diff --quiet HEAD^ HEAD`) errors when `HEAD^` doesn't exist (first commit / shallow clone) and Vercel then builds anyway.

Guarded with `git rev-parse --verify HEAD^`:
- **no parent** → build (safe default — never skip when we can't tell)
- **parent + no relay change** → skip
- **parent + relay change** → build

Keeps the `:/packages/telemetry-relay` root-relative pathspec so it resolves from the project's Root Directory. (Squash-merges to main — our only merge path — compare the squashed commit to its parent, so real relay changes are always detected.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)