### PR TITLE
feat(telemetry): anonymous prs_created count (v0.19.6)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fullstack-dev-kit",
-  "version": "0.19.5",
+  "version": "0.19.6",
   "description": "Issue-to-PR workflow kit for any tech stack. Fetch a user story from your tracker (Jira, Linear, GitHub Issues, Azure DevOps) and any linked Figma designs, implement with plan approval, enforce >95% coverage and a security pass, generate e2e tests, open the PR, fix review findings, and move the ticket to review.",
   "license": "Apache-2.0",
   "homepage": "https://github.com/theam/claude-dev-kit",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The `version` in `.claude-plugin/plugin.json` is what reaches installed clients 
 a release is only "live" for users once that is bumped and published.
 
 ## [Unreleased]
+### Added
+- **`prs_created` telemetry (opt-in, anonymous).** Each session event now carries a **count** of pull requests opened, so aggregate impact can be measured by outcome (PRs shipped), not just token usage. Derived by matching the *executed* PR-create command per host (`gh pr create` · `glab mr create` · Bitbucket create-PR API) — never the PR's URL, repo, title, or body, and never the skill text that mentions the command. Added to the contract (both copies) and documented in `TELEMETRY.md`. Kit → **0.19.6** (client `scripts/telemetry.mjs` ships to users; relay redeploys with the new contract).
+
 ### Fixed
 - **Bundle drift is now caught by validation.** `plugins/fullstack-dev-kit/{skills,instructions}/`
   are generated copies, but `validate-codex-plugin.mjs` only checked that referenced files

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -61,7 +61,8 @@ One POST (to the relay), only for sessions where the kit ran, matching the contr
     "tokens_output": 9134,
     "tokens_cache_read": 120400,
     "tokens_cache_creation": 3300,
-    "tokens_total": 181044
+    "tokens_total": 181044,
+    "prs_created": 1
   }
 }
 ```
@@ -72,10 +73,11 @@ One POST (to the relay), only for sessions where the kit ran, matching the contr
 - `tracker_type` — the *category* (jira / linear / github / azure), never the site, project, or instance.
 - `duration_bucket` — a coarse range, never a raw timestamp.
 - `tokens_*` — sums parsed from the session transcript's `usage` fields.
+- `prs_created` — a **count** of pull requests opened in the session. Derived by matching the *executed* command (e.g. `gh pr create`, `glab mr create`, a Bitbucket create-PR API call) — never the PR's URL, repo, title, or body, and never the skill text that merely mentions the command. Just the number.
 
 ## What is NEVER sent
 
-Prompts, responses, code, diffs, file paths, file names, repo names or URLs, ticket keys or contents, commit messages, branch names, emails, usernames, organization-instance data, or your IP (stripped at the relay). The client reads the transcript **only** to sum token counts and to check whether a kit component ran.
+Prompts, responses, code, diffs, file paths, file names, repo names or URLs (including PR URLs), ticket keys or contents, commit messages, branch names, emails, usernames, organization-instance data, or your IP (stripped at the relay). The client reads the transcript **only** to sum token counts, to check whether a kit component ran, and to count executed PR-create commands.
 
 ## Company attribution (optional, organisation-level)
 

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -6,7 +6,7 @@ claude-dev-kit can share **anonymous, opt-in** usage telemetry so The Agile Monk
 
 - **OFF by default.** Nothing is sent unless you explicitly opt in.
 - **Anonymous.** Identified only by a random `install_id`. No account, email, org-instance, or repo is attached.
-- **Token counts only.** How *many* tokens a session used — never *what* was in them.
+- **Counts only.** How *many* tokens a session used, and *how many* PRs it opened — never *what* was in them.
 - **No key in the client, no direct PostHog call.** Clients POST to a relay that re-enforces the contract and strips your IP before forwarding.
 - **Honest attribution.** Only sessions where a kit command/agent actually ran are reported.
 - **Auditable.** Client: [`scripts/telemetry.mjs`](./scripts/telemetry.mjs). Contract: [`telemetry/contract.v1.json`](./telemetry/contract.v1.json). Relay: [`packages/telemetry-relay/`](./packages/telemetry-relay/).

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -73,7 +73,7 @@ One POST (to the relay), only for sessions where the kit ran, matching the contr
 - `tracker_type` — the *category* (jira / linear / github / azure), never the site, project, or instance.
 - `duration_bucket` — a coarse range, never a raw timestamp.
 - `tokens_*` — sums parsed from the session transcript's `usage` fields.
-- `prs_created` — a **count** of pull requests opened in the session. Derived by matching the *executed* command (e.g. `gh pr create`, `glab mr create`, a Bitbucket create-PR API call) — never the PR's URL, repo, title, or body, and never the skill text that merely mentions the command. Just the number.
+- `prs_created` — a **count** of pull requests opened in the session. Derived by matching the PR-create command at a command position (e.g. `gh pr create`, `glab mr create`, a Bitbucket create-PR API call) — never the PR's URL, repo, title, or body, and never the skill text or a command that merely mentions the phrase. It is **best-effort** (a loose upper bound): a retried or failed attempt may over-count. Just the number, nothing else.
 
 ## What is NEVER sent
 

--- a/packages/telemetry-relay/contract.v1.json
+++ b/packages/telemetry-relay/contract.v1.json
@@ -17,7 +17,8 @@
     "tokens_output": { "type": "integer", "min": 0 },
     "tokens_cache_read": { "type": "integer", "min": 0 },
     "tokens_cache_creation": { "type": "integer", "min": 0 },
-    "tokens_total": { "type": "integer", "min": 0 }
+    "tokens_total": { "type": "integer", "min": 0 },
+    "prs_created": { "type": "integer", "min": 0, "optional": true }
   },
   "identity": {
     "distinct_id": "random per-install UUID (install_id) — not derived from any personal or machine attribute",

--- a/plugins/fullstack-dev-kit/.codex-plugin/plugin.json
+++ b/plugins/fullstack-dev-kit/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fullstack-dev-kit",
-  "version": "0.19.5",
+  "version": "0.19.6",
   "description": "Issue-to-PR workflow for any tech stack: fetch stories from Jira/Linear/GitHub/Azure and Figma designs, plan-approval gate, adaptive quality + coverage gates, e2e generation, PR creation and review.",
   "author": {
     "name": "The Agile Monkeys",

--- a/plugins/fullstack-dev-kit/plugin.json
+++ b/plugins/fullstack-dev-kit/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "fullstack-dev-kit",
-  "version": "0.19.5",
+  "version": "0.19.6",
   "description": "Issue-to-PR workflow for any tech stack: fetch stories from Jira/Linear/GitHub/Azure and Figma designs, plan-approval gate, adaptive quality + coverage gates, e2e generation, PR creation and review.",
   "author": {
     "name": "The Agile Monkeys",

--- a/scripts/lib/pr-detect.mjs
+++ b/scripts/lib/pr-detect.mjs
@@ -1,0 +1,45 @@
+/*
+ * pr-detect — count pull requests opened in a session, from its transcript.
+ *
+ * Privacy-critical: the match is against the *executed command* only (Claude: a Bash
+ * tool_use input; Codex: an exec_command's `cmd`), never against instructions or command
+ * output. So the create-pr skill merely *mentioning* `gh pr create`, or a command that
+ * reads the skill file, cannot inflate the count. Only an integer count is ever emitted —
+ * no PR URL, repo, title, or body. See TELEMETRY.md.
+ */
+
+/** True if an executed shell command opens a PR on one of the hosts create-pr supports. */
+export function isPrCreate(cmd) {
+  return typeof cmd === 'string' && (
+    /\bgh\s+pr\s+create\b/.test(cmd) ||                                          // github
+    /\bglab\s+mr\s+create\b/.test(cmd) ||                                        // gitlab
+    (/api\.bitbucket\.org/.test(cmd) && /pullrequests\b/.test(cmd) && /\bPOST\b/.test(cmd)) // bitbucket REST
+  );
+}
+
+/**
+ * Count PR-create commands executed in a session transcript.
+ * @param {string[]} lines  JSONL lines of the transcript/rollout.
+ * @param {'claude-code'|'codex'} agent  which host produced the transcript.
+ */
+export function countPrCreated(lines, agent) {
+  let n = 0;
+  for (const line of lines) {
+    let o; try { o = JSON.parse(line); } catch { continue; }
+    if (agent === 'codex') {
+      const p = o?.payload;
+      if (p?.type === 'function_call' && p?.name === 'exec_command') {
+        let a; try { a = JSON.parse(p.arguments || '{}'); } catch { a = {}; }
+        if (isPrCreate(a?.cmd)) n++;
+      }
+    } else {
+      const content = o?.message?.content;
+      if (Array.isArray(content)) {
+        for (const b of content) {
+          if (b?.type === 'tool_use' && b?.name === 'Bash' && isPrCreate(b?.input?.command)) n++;
+        }
+      }
+    }
+  }
+  return n;
+}

--- a/scripts/lib/pr-detect.mjs
+++ b/scripts/lib/pr-detect.mjs
@@ -8,13 +8,19 @@
  * no PR URL, repo, title, or body. See TELEMETRY.md.
  */
 
+// A create invocation must sit at a COMMAND POSITION — the start of the command, or
+// right after a shell separator (`;` `&&` `||` `|` `&`), optionally behind `sudo` or
+// env-var assignments — so the phrase quoted inside grep/echo/commit messages, in a
+// comment, or in a file being read does NOT count. `-h`/`--help` invocations are excluded.
+// This is a best-effort COUNT (a loose upper bound): a retried or failed attempt can
+// over-count. Only the integer is ever emitted — never the command. See TELEMETRY.md.
+const CREATE_CLI = /(?:^|[;&|]\s*)(?:sudo\s+)?(?:[A-Za-z_][A-Za-z0-9_]*=\S*\s+)*(?:gh\s+pr\s+create|glab\s+mr\s+create)\b(?![^\n]*\s(?:-h|--help)\b)/;
+
 /** True if an executed shell command opens a PR on one of the hosts create-pr supports. */
 export function isPrCreate(cmd) {
-  return typeof cmd === 'string' && (
-    /\bgh\s+pr\s+create\b/.test(cmd) ||                                          // github
-    /\bglab\s+mr\s+create\b/.test(cmd) ||                                        // gitlab
-    (/api\.bitbucket\.org/.test(cmd) && /pullrequests\b/.test(cmd) && /\bPOST\b/.test(cmd)) // bitbucket REST
-  );
+  if (typeof cmd !== 'string') return false;
+  if (CREATE_CLI.test(cmd)) return true;                                          // github / gitlab CLI
+  return /api\.bitbucket\.org/.test(cmd) && /pullrequests\b/.test(cmd) && /\bPOST\b/.test(cmd); // bitbucket REST
 }
 
 /**

--- a/scripts/telemetry-pr-detect.test.mjs
+++ b/scripts/telemetry-pr-detect.test.mjs
@@ -1,0 +1,57 @@
+/*
+ * Tests for the PR-create detector used by the telemetry client. Zero-dep (node:test).
+ *
+ * The property that matters for privacy + accuracy: the count reflects PR-create
+ * commands that were *executed*, and is NOT inflated by the skill text mentioning the
+ * command, by a command that reads the skill file, or by non-create PR commands.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { isPrCreate, countPrCreated } from './lib/pr-detect.mjs';
+
+const claudeBash = (command) => JSON.stringify({ type: 'assistant', message: { content: [{ type: 'tool_use', name: 'Bash', input: { command } }] } });
+const claudeText = (text) => JSON.stringify({ type: 'assistant', message: { content: [{ type: 'text', text }] } });
+const claudeResult = (content) => JSON.stringify({ type: 'user', message: { content: [{ type: 'tool_result', content }] } });
+const codexExec = (cmd) => JSON.stringify({ payload: { type: 'function_call', name: 'exec_command', arguments: JSON.stringify({ cmd }) } });
+const codexOutput = (out) => JSON.stringify({ payload: { type: 'function_call_output', name: 'exec_command', arguments: out } });
+
+test('isPrCreate matches create commands per host, not reads/views', () => {
+  assert.ok(isPrCreate('gh pr create --fill'));
+  assert.ok(isPrCreate('glab mr create -t x'));
+  assert.ok(isPrCreate("curl -X POST https://api.bitbucket.org/2.0/repositories/w/r/pullrequests -d @body.json"));
+  assert.ok(!isPrCreate('gh pr view 12'));
+  assert.ok(!isPrCreate('gh pr edit 12 --add-label ai-generated'));
+  assert.ok(!isPrCreate('gh pr list'));
+  assert.ok(!isPrCreate('curl https://api.bitbucket.org/2.0/repositories/w/r/pullrequests')); // GET list, no POST
+  assert.ok(!isPrCreate(undefined));
+});
+
+test('Claude: counts executed Bash create commands only', () => {
+  const lines = [
+    claudeBash('git push -u origin feat/x'),
+    claudeBash('gh pr create --title X --body Y'),
+    claudeText('I will now run gh pr create to open the PR'),   // narration → not counted
+    claudeResult('the create-pr skill uses `gh pr create`'),    // doc/output → not counted
+    claudeBash('gh pr view 12'),                                // view → not counted
+  ];
+  assert.equal(countPrCreated(lines, 'claude-code'), 1);
+});
+
+test('Codex: counts exec_command create cmds, ignores reads of the skill file and outputs', () => {
+  const lines = [
+    codexExec("sed -n '1,240p' create-pr/SKILL.md"),  // reads a file that mentions the command → not counted
+    codexExec('gh pr create --fill'),
+    codexOutput('output mentions gh pr create'),        // output, not a command → not counted
+  ];
+  assert.equal(countPrCreated(lines, 'codex'), 1);
+});
+
+test('no PR-create commands → 0; malformed lines are skipped', () => {
+  assert.equal(countPrCreated([claudeBash('npm test'), 'not json', ''], 'claude-code'), 0);
+  assert.equal(countPrCreated([], 'codex'), 0);
+});
+
+test('multiple PRs in one session are each counted', () => {
+  const lines = [claudeBash('gh pr create --fill'), claudeBash('glab mr create -t y')];
+  assert.equal(countPrCreated(lines, 'claude-code'), 2);
+});

--- a/scripts/telemetry-pr-detect.test.mjs
+++ b/scripts/telemetry-pr-detect.test.mjs
@@ -18,10 +18,16 @@ const codexOutput = (out) => JSON.stringify({ payload: { type: 'function_call_ou
 test('isPrCreate matches create commands per host, not reads/views', () => {
   assert.ok(isPrCreate('gh pr create --fill'));
   assert.ok(isPrCreate('glab mr create -t x'));
+  assert.ok(isPrCreate('cd repo && gh pr create --fill'));                 // after a shell separator
+  assert.ok(isPrCreate('GH_TOKEN=xxx gh pr create --fill'));               // behind an env assignment
   assert.ok(isPrCreate("curl -X POST https://api.bitbucket.org/2.0/repositories/w/r/pullrequests -d @body.json"));
   assert.ok(!isPrCreate('gh pr view 12'));
   assert.ok(!isPrCreate('gh pr edit 12 --add-label ai-generated'));
   assert.ok(!isPrCreate('gh pr list'));
+  assert.ok(!isPrCreate('gh pr create --help'));                           // help, not a real create
+  assert.ok(!isPrCreate("grep 'gh pr create' skills/create-pr/SKILL.md")); // the phrase quoted in a read
+  assert.ok(!isPrCreate('echo "next: gh pr create"'));                     // narration echoed to the shell
+  assert.ok(!isPrCreate('git commit -m "wire up gh pr create detection"')); // the phrase in a commit message
   assert.ok(!isPrCreate('curl https://api.bitbucket.org/2.0/repositories/w/r/pullrequests')); // GET list, no POST
   assert.ok(!isPrCreate(undefined));
 });
@@ -40,10 +46,30 @@ test('Claude: counts executed Bash create commands only', () => {
 test('Codex: counts exec_command create cmds, ignores reads of the skill file and outputs', () => {
   const lines = [
     codexExec("sed -n '1,240p' create-pr/SKILL.md"),  // reads a file that mentions the command → not counted
+    codexExec("grep 'gh pr create' SKILL.md"),         // greps for the phrase → not counted (command position)
     codexExec('gh pr create --fill'),
     codexOutput('output mentions gh pr create'),        // output, not a command → not counted
   ];
   assert.equal(countPrCreated(lines, 'codex'), 1);
+});
+
+test('Codex: matches the real 0.147 rollout shape (response_item → function_call → exec_command)', () => {
+  // Mirrors a captured codex-cli 0.147 line: outer type "response_item", payload
+  // "function_call"/"exec_command", `arguments` a JSON STRING of {cmd, workdir, …}.
+  // If a future Codex format drifts from this, this test fails instead of the metric
+  // silently zeroing.
+  const realShape = JSON.stringify({
+    timestamp: '2026-08-05T13:42:42.626Z',
+    type: 'response_item',
+    payload: {
+      type: 'function_call',
+      id: 'fc_x',
+      name: 'exec_command',
+      arguments: JSON.stringify({ cmd: 'gh pr create --fill', workdir: '/w', yield_time_ms: 1000, max_output_tokens: 20000 }),
+      call_id: 'call_x',
+    },
+  });
+  assert.equal(countPrCreated([realShape], 'codex'), 1);
 });
 
 test('no PR-create commands → 0; malformed lines are skipped', () => {
@@ -53,5 +79,12 @@ test('no PR-create commands → 0; malformed lines are skipped', () => {
 
 test('multiple PRs in one session are each counted', () => {
   const lines = [claudeBash('gh pr create --fill'), claudeBash('glab mr create -t y')];
+  assert.equal(countPrCreated(lines, 'claude-code'), 2);
+});
+
+test('retries over-count by design (best-effort upper bound)', () => {
+  // A failed first attempt + a successful retry counts as 2. Documented in TELEMETRY.md;
+  // acceptable for a coarse anonymous aggregate.
+  const lines = [claudeBash('gh pr create --fill'), claudeBash('gh pr create --fill')];
   assert.equal(countPrCreated(lines, 'claude-code'), 2);
 });

--- a/scripts/telemetry.mjs
+++ b/scripts/telemetry.mjs
@@ -31,6 +31,7 @@ import { homedir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { randomUUID, createHash } from 'node:crypto';
+import { countPrCreated } from './lib/pr-detect.mjs';
 
 const done = () => process.exit(0); // fail-silent, always
 
@@ -155,7 +156,8 @@ try {
   }
 
   // Compute one session's event from its transcript and POST it. Content is
-  // never inspected beyond summing `usage` and checking a kit component ran.
+  // never inspected beyond summing `usage`, checking a kit component ran, and
+  // counting executed PR-create commands.
   async function flush(transcriptPath, cwd, ep, ccVersion, dedup, agent) {
     if (!transcriptPath || !existsSync(transcriptPath)) return;
     const lines = readFileSync(transcriptPath, 'utf8').split('\n').filter(Boolean);
@@ -233,6 +235,7 @@ try {
         tokens_cache_read: tok.cacheRead,
         tokens_cache_creation: tok.cacheCreation,
         tokens_total: tok.input + tok.output + tok.cacheRead + tok.cacheCreation,
+        prs_created: countPrCreated(lines, agent),
       },
     };
     const ctl = new AbortController();

--- a/telemetry/contract.v1.json
+++ b/telemetry/contract.v1.json
@@ -17,7 +17,8 @@
     "tokens_output": { "type": "integer", "min": 0 },
     "tokens_cache_read": { "type": "integer", "min": 0 },
     "tokens_cache_creation": { "type": "integer", "min": 0 },
-    "tokens_total": { "type": "integer", "min": 0 }
+    "tokens_total": { "type": "integer", "min": 0 },
+    "prs_created": { "type": "integer", "min": 0, "optional": true }
   },
   "identity": {
     "distinct_id": "random per-install UUID (install_id) — not derived from any personal or machine attribute",


### PR DESCRIPTION
Adds a `prs_created` metric so we can measure the kit's impact by **outcome** (PRs opened), not just token usage. Anonymous and opt-in, same as the rest of the telemetry.

## What lands in PostHog
A single integer per session event: `prs_created`. **Never** a PR URL, repo, title, or body.

## How it's detected (privacy-critical)
Extracted into `scripts/lib/pr-detect.mjs` and matched against the **executed command only**:
- **Claude Code** — a Bash `tool_use` input
- **Codex** — an `exec_command`'s `cmd` (verified against a real 0.147 rollout)

Commands matched: `gh pr create` (github), `glab mr create` (gitlab), Bitbucket create-PR API (`POST .../pullrequests`). It does **not** match:
- the create-pr skill *text* that mentions the command,
- a command that *reads* the skill file,
- command *output*,
- `gh pr view` / `edit` / `list`.

## Full change set
- `scripts/telemetry.mjs` — emit `prs_created` in the session payload (via the new module).
- `scripts/lib/pr-detect.mjs` — `isPrCreate` + `countPrCreated` (importable, testable).
- `telemetry/contract.v1.json` + `packages/telemetry-relay/contract.v1.json` — add the property (relay drops anything not in the contract).
- `TELEMETRY.md` — documents exactly what's collected and what isn't.
- Kit → **0.19.6** (client ships to users; the relay redeploys with the new contract so the property is accepted).

## Verification
```
node scripts/build-codex-plugin.mjs && node scripts/validate-codex-plugin.mjs && node --test && git diff --exit-code
# validate ✓ · node --test → 10/10 (5 new pr-detect + 5 bundle) · tree clean
```

Note: merging this touches `packages/telemetry-relay/`, so Vercel redeploys the relay with the new contract (required for the property to be forwarded rather than dropped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)