### PR TITLE
chore(ci): GitHub Actions + contract-parity guard + doc fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      # 1. The committed bundle must be valid and in sync with its sources.
+      - name: Validate the plugin bundle
+        run: node scripts/validate-codex-plugin.mjs
+
+      # 2. Zero-dep test suite (node:test): drift guard + PR-create detector + contract parity.
+      - name: Run tests
+        run: node --test scripts/*.test.mjs
+
+      # 3. Rebuilding must be a no-op on a committed tree — proves the bundle and the
+      #    generated manifests match their canonical sources (skip-build drift = failure).
+      - name: Rebuild and assert no drift
+        run: |
+          node scripts/build-codex-plugin.mjs
+          git diff --exit-code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ a release is only "live" for users once that is bumped and published.
 
 ## [Unreleased]
 ### Added
+- **CI (GitHub Actions).** `.github/workflows/ci.yml` runs on every push to `main` and every PR: validate the bundle, `node --test`, then rebuild and `git diff --exit-code` to assert the committed bundle/manifests are in sync. Catches skip-build drift, stale manifests, and contract divergence automatically — the failure modes we previously found by hand.
+- **Contract-parity guard.** `scripts/contract-parity.test.mjs` asserts the two `contract.v1.json` copies (client + relay) are byte-identical, so a property added to one but not the other can't silently drift.
 - **`prs_created` telemetry (opt-in, anonymous).** Each session event now carries a **count** of pull requests opened, so aggregate impact can be measured by outcome (PRs shipped), not just token usage. Derived by matching the *executed* PR-create command per host (`gh pr create` · `glab mr create` · Bitbucket create-PR API) — never the PR's URL, repo, title, or body, and never the skill text that mentions the command. Added to the contract (both copies) and documented in `TELEMETRY.md`. Kit → **0.19.6** (client `scripts/telemetry.mjs` ships to users; relay redeploys with the new contract).
 
 ### Fixed

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -37,7 +37,7 @@ This mirrors the relay pattern used by [theam/limina](https://github.com/theam/l
 
 ## Delivery (robust to sessions that never close)
 
-One event per session. Normally it's sent at `SessionEnd`. To also cover sessions that never close cleanly (a crash, or a session left open indefinitely), the client keeps a tiny **outbox**: a `Stop` hook records a lightweight per-session marker (session id + transcript path + timestamp — no token parsing, no network), and the next `SessionStart` flushes markers of *prior* sessions that went stale (unrefreshed for 30 min). A still-open parallel session keeps refreshing its marker, so it's never sent early. State lives in `~/.claude/dev-kit-telemetry/pending.json`, is created **only if you opted in**, and self-cleans once an event is sent.
+One event per session. Normally it's sent at `SessionEnd`. To also cover sessions that never close cleanly (a crash, or a session left open indefinitely), the client keeps a tiny **outbox**: a `Stop` hook records a lightweight per-session marker (session id + transcript path + timestamp — no token parsing, no network), and the next `SessionStart` flushes markers of *prior* sessions that went stale (unrefreshed for 10 min). A still-open parallel session keeps refreshing its marker, so it's never sent early. State lives in `~/.claude/dev-kit-telemetry/pending.json`, is created **only if you opted in**, and self-cleans once an event is sent.
 
 ## Exactly what is sent
 

--- a/scripts/contract-parity.test.mjs
+++ b/scripts/contract-parity.test.mjs
@@ -1,0 +1,22 @@
+/*
+ * The telemetry contract exists in two places — telemetry/contract.v1.json (what the
+ * client reads for the relay URL / documents) and packages/telemetry-relay/contract.v1.json
+ * (what the relay bundles and enforces). They MUST stay byte-identical: if they drift, the
+ * client can send a property the relay silently drops (or vice-versa). This guards that.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+test('the two telemetry contract copies are byte-identical', () => {
+  const client = readFileSync(join(ROOT, 'telemetry', 'contract.v1.json'));
+  const relay = readFileSync(join(ROOT, 'packages', 'telemetry-relay', 'contract.v1.json'));
+  assert.ok(
+    client.equals(relay),
+    'telemetry/contract.v1.json and packages/telemetry-relay/contract.v1.json differ — keep them in sync (a property in one but not the other is sent-but-dropped)',
+  );
+});


### PR DESCRIPTION
First "harden the project" batch — small, high-leverage, no version bump.

## CI (there was none)
`.github/workflows/ci.yml` runs on push to `main` and every PR:
1. `node scripts/validate-codex-plugin.mjs` — the committed bundle is valid + in sync.
2. `node --test scripts/*.test.mjs` — drift guard, PR-create detector, contract parity.
3. `node scripts/build-codex-plugin.mjs && git diff --exit-code` — rebuilding is a no-op on a committed tree (skip-build drift fails CI).

This would have auto-caught the bundle-drift (#40/#42) and the `interface.category` (#45-era) issues we found by hand. Zero-dep, no `npm ci`.

## Contract-parity guard
`scripts/contract-parity.test.mjs` asserts `telemetry/contract.v1.json` and `packages/telemetry-relay/contract.v1.json` are byte-identical — we keep them in sync manually today, and a divergence means a property is sent-but-dropped.

## Doc fix
`TELEMETRY.md` said stale markers flush after **30 min**; the code (`STALE_MS`) is **10 min**. Corrected.

## Verification
```
node scripts/validate-codex-plugin.mjs   # ✓
node --test scripts/*.test.mjs           # 16/16
node scripts/build-codex-plugin.mjs && git diff --exit-code   # no drift
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)