### PR TITLE
docs(readme): CI + license badges, multi-client line (#47)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,14 @@
 
 An open-source [Claude Code](https://code.claude.com) plugin by [The Agile Monkeys](https://www.theagilemonkeys.com): a **stack-agnostic issue-to-PR workflow** with enforced quality gates. Also runs on **OpenAI Codex**, **Cursor**, and other [Agent Plugins 1.0.0](https://agent-plugins.org) clients.
 
+## Demo
+
+The kit taking a ticket all the way to an opened PR (test project *yardflow*):
+
+https://github.com/user-attachments/assets/21afb5ab-b52b-4418-bf01-d247e8d73208
+
+## How it works
+
 Give the `coding-agent` a user story ID from your tracker and it orchestrates the whole flow:
 
 ```

--- a/README.md
+++ b/README.md
@@ -28,7 +28,16 @@ Give the `coding-agent` a user story ID from your tracker and it orchestrates th
 npm create @theagilemonkeys/dev-kit
 ```
 
-Interactive setup — tracker, Figma, telemetry consent, org — then it installs the plugin for you. Full options in [Installing in Claude Code](#installing-in-claude-code).
+Interactive setup — tracker, Figma, telemetry consent, org — then it installs the plugin for whichever agents you have (Claude Code / Codex / Cursor). Full options in [Installing in Claude Code](#installing-in-claude-code).
+
+**On OpenAI Codex** you can also install it natively:
+
+```bash
+codex plugin marketplace add theam/claude-dev-kit
+codex plugin add fullstack-dev-kit@claude-dev-kit
+```
+
+Then run `$work-story PROJ-1234` (or any single skill, e.g. `$pr-review`). More — including Cursor and Copilot — in [Also runs on Codex, Cursor & Copilot](#also-runs-on-codex-cursor--copilot-experimental).
 
 ## Stack-agnostic by design
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # claude-dev-kit
 
-An open-source [Claude Code](https://code.claude.com) plugin by [The Agile Monkeys](https://www.theagilemonkeys.com): a **stack-agnostic issue-to-PR workflow** with enforced quality gates.
+[![CI](https://github.com/theam/claude-dev-kit/actions/workflows/ci.yml/badge.svg)](https://github.com/theam/claude-dev-kit/actions/workflows/ci.yml)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+
+An open-source [Claude Code](https://code.claude.com) plugin by [The Agile Monkeys](https://www.theagilemonkeys.com): a **stack-agnostic issue-to-PR workflow** with enforced quality gates. Also runs on **OpenAI Codex**, **Cursor**, and other [Agent Plugins 1.0.0](https://agent-plugins.org) clients.
 
 Give the `coding-agent` a user story ID from your tracker and it orchestrates the whole flow:
 


### PR DESCRIPTION
Part of #47. The reliable, no-fabrication pieces:

- CI status badge (now that `ci.yml` is on `main`) + Apache-2.0 license badge, under the title.
- One line noting the kit also runs on Codex / Cursor / Agent Plugins 1.0.0 clients.

**Still open in #47** (need input, not blocking this PR):
- The **OpenAI Plugins Directory "Try in ChatGPT" URL** — I don't have it; once you paste the public `chatgpt.com/...` link I'll add a badge/callout.
- A short **demo GIF** of the ticket → PR flow (needs a real recording).

🤖 Generated with [Claude Code](https://claude.com/claude-code)