### PR TITLE
refactor(validate): lead with a skill-name collision instead of the drift it causes

### DIFF
--- a/scripts/validate-codex-plugin.mjs
+++ b/scripts/validate-codex-plugin.mjs
@@ -98,11 +98,6 @@ else {
   }
 }
 
-// 3b. Skill-name collisions across collections that share a destination.
-for (const { name, sources } of skillNameCollisions(ROOT)) {
-  errs.push(`skill "${name}" is defined in both ${sources[0]}/ and ${sources[1]}/ — they copy to the same place`);
-}
-
 // 4. Self-contained bundle + portable skill-name rules.
 const skillsDir = join(PLUGIN, 'skills');
 if (existsSync(skillsDir)) {
@@ -135,9 +130,18 @@ for (const { src, dst, label } of syncedFilePairs(ROOT)) {
   if (readFileSync(src).equals(readFileSync(dst))) continue;
   drifted.push(label);
 }
-for (const label of missing) errs.push(`bundle is missing "${label}" — run build-codex-plugin.mjs`);
-for (const label of drifted) errs.push(`bundle copy of "${label}" differs from the source — run build-codex-plugin.mjs`);
-for (const orphan of orphanedBundleFiles(ROOT)) errs.push(`bundle still carries "${orphan}", which no source produces — run build-codex-plugin.mjs`);
+// A name collision makes the "losing" copy read as drift, so the per-file drift/orphan
+// lines below would be derivative noise. Lead with the cause and suppress them while a
+// collision is present; the manifest pair is orthogonal to it, so that stays unconditional.
+const collisions = skillNameCollisions(ROOT);
+for (const { name, sources } of collisions) {
+  errs.push(`skill "${name}" is defined in both ${sources[0]}/ and ${sources[1]}/ — they copy to the same place`);
+}
+if (!collisions.length) {
+  for (const label of missing) errs.push(`bundle is missing "${label}" — run build-codex-plugin.mjs`);
+  for (const label of drifted) errs.push(`bundle copy of "${label}" differs from the source — run build-codex-plugin.mjs`);
+  for (const orphan of orphanedBundleFiles(ROOT)) errs.push(`bundle still carries "${orphan}", which no source produces — run build-codex-plugin.mjs`);
+}
 
 if (errs.length) {
   console.error('✗ Codex plugin validation failed:');

--- a/scripts/validate-codex-plugin.test.mjs
+++ b/scripts/validate-codex-plugin.test.mjs
@@ -44,8 +44,10 @@ function sandbox() {
   return dir;
 }
 
+/* The sandbox carries its own scripts/, and each script self-locates via import.meta.url,
+ * so invoking the copy is what targets the copy. No cwd or env override is involved. */
 const run = (root, script) =>
-  spawnSync(process.execPath, [join(root, 'scripts', script)], { encoding: 'utf8', cwd: root });
+  spawnSync(process.execPath, [join(root, 'scripts', script)], { encoding: 'utf8' });
 const validate = (root) => run(root, 'validate-codex-plugin.mjs');
 const build = (root) => run(root, 'build-codex-plugin.mjs');
 
@@ -154,6 +156,44 @@ test('a skill name in two collections is rejected rather than silently overwritt
     const result = validate(dir);
     assert.equal(result.status, 1, 'validator ignored the collision');
     assert.match(result.stderr, /defined in both/);
+  });
+});
+
+test('a collision leads, and does not drag the drift it causes along with it', () => {
+  inSandbox((dir) => {
+    // Give the two collections a same-named skill whose contents differ, so the losing
+    // copy would otherwise also be reported as drift — the derivative noise this hides.
+    const dup = join(dir, 'skills', 'work-story');
+    cpSync(join(dir, 'codex', 'skills', 'work-story'), dup, { recursive: true });
+    writeFileSync(join(dup, 'SKILL.md'), `${readFileSync(join(dup, 'SKILL.md'), 'utf8')}\n<!-- diverged -->\n`);
+
+    const result = validate(dir);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /defined in both/, 'the cause is not reported');
+    assert.doesNotMatch(
+      result.stderr,
+      /differs from the source|bundle is missing|which no source produces/,
+      'per-file drift lines should be suppressed while a collision is present',
+    );
+  });
+});
+
+test('manifest drift is still reported while a collision is present', () => {
+  // The manifest pair is orthogonal to skill-name collisions, so suppressing the
+  // per-file lines must not suppress it too.
+  inSandbox((dir) => {
+    cpSync(join(dir, 'codex', 'skills', 'work-story'), join(dir, 'skills', 'work-story'), {
+      recursive: true,
+    });
+    const codex = join(dir, CODEX_MANIFEST);
+    const manifest = JSON.parse(readFileSync(codex, 'utf8'));
+    manifest.description = `${manifest.description} (drift probe)`;
+    writeFileSync(codex, `${JSON.stringify(manifest, null, 2)}\n`);
+
+    const result = validate(dir);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /defined in both/);
+    assert.match(result.stderr, /differs from the source it is generated from/);
   });
 });
 


### PR DESCRIPTION
<!-- Thanks for contributing! Keep PRs small and single-concern. -->

## What & why

For completeness — the two optional notes from your review of #42, so neither is left dangling. Both are small and neither changes what validation catches, only how it reports and how the tests are wired. Happy for this to sit, be squashed into something larger, or be closed if you would rather keep the noise as-is.

**1. A collision now leads, and does not drag the drift it causes along with it.** Taken from your implementation in #43 rather than reinvented, including the distinction in your comment there — the per-file `missing` / `differs from the source` / `which no source produces` lines are suppressed while a collision is present, but the manifest pair is *orthogonal* to a name collision, so that check stays unconditional.

A collision where the two copies also differ, before and after:

```console
# before
✗ Codex plugin validation failed:
  - skill "work-story" is defined in both skills/ and codex/skills/ — they copy to the same place
  - bundle copy of "skills/work-story/SKILL.md" differs from the source — run build-codex-plugin.mjs

# after
✗ Codex plugin validation failed:
  - skill "work-story" is defined in both skills/ and codex/skills/ — they copy to the same place
```

And with a collision *and* a stale manifest, both still report — that's the second new test.

**2. `cwd: root` removed from the test `run()` helper.** You were right that it did nothing: the sandbox carries its own `scripts/`, and each script self-locates through `import.meta.url`, so invoking the copy is what targets the copy. Replaced with a comment saying so, since the next reader will have the same question.

## Deliberately not taken from #43

`DEVKIT_ROOT`. You named its absence as one of the two reasons for keeping #42, so adding it now would undo exactly that. The sandbox-copy approach gets the same isolation without a test-only knob in the shipping build and validate scripts.

I also kept `skillNameCollisions()` (returns `{name, sources}`, which is what lets the message name both directories) over `collidingSkillNames()` — only because the former is already on `main` and renaming it would be churn on merged code.

## Whether this is coherent with the rest of the guard

Worth stating explicitly, because it is the reason this is a two-line idea rather than a preference:

- **Report causes, not consequences.** Suppressing derived diagnostics after a root failure is ordinary compiler and linter practice — cascading errors bury the one you can act on. The discipline that stops it becoming error-*hiding* is distinguishing failures that are **dependent** on the root cause (the losing copy reads as drift *because* of the collision) from ones that merely **co-occur** (a stale manifest has no causal link to a duplicate skill name). Your #43 comment draws exactly that line, and the two tests pin both halves so a future change cannot quietly widen the suppression.
- **Test seams stay out of shipping code.** Arranging a hermetic fixture — copy the tree, run the copy — gets the same isolation as an injected root without a branch in `build-codex-plugin.mjs` and `validate-codex-plugin.mjs` that only exists for tests.
- **Dead configuration is worse than none.** A `cwd` that looks load-bearing invites someone to change it while chasing a real bug.

All three sit under the property the guard family already has: *don't check that generated output exists, re-derive it and compare* — trees in #40, manifests in #42, and now `build && git diff --exit-code` in your CI from #46. This PR does not add to that property; it keeps its failure output legible when two of its checks fire at once.

## Type
- [x] Bug fix
- [ ] New/improved stack profile (`instructions/stacks/…`)
- [ ] New/improved adapter (tracker / PR host)
- [ ] Docs
- [x] Other: diagnostics + test wiring

## Verification

Your `ci.yml`, run verbatim on this branch:

```console
$ node scripts/validate-codex-plugin.mjs
✓ Codex plugin bundle is valid …
$ node --test scripts/*.test.mjs
# tests 18   # pass 18   # fail 0
$ node scripts/build-codex-plugin.mjs && git diff --exit-code
$ echo $?
0
```

Two new tests: a collision with divergent contents reports the cause and nothing derived from it; a tree with both a collision and manifest drift still reports both.

## One thing I did not change

In #43 the manifest byte-compare runs last, so a collision line prints above it. Here the portable-manifest checks are grouped together in section 3, so when a tree has both problems the manifest line prints first. Behaviour is identical and the suppression is unaffected — it is purely print order, and it falls out of a structure that is already on `main`. Say the word and I will move it so the collision leads strictly.

## Checklist
- [x] Keeps the kit **stack-agnostic** — tooling only.
- [x] Doesn't weaken the quality gates or the telemetry privacy guarantees — the suppressed lines are strictly derivative of an error that is still reported; nothing that can fail alone was silenced.
- [x] Docs updated in the same PR — none needed; no contributor-facing behaviour changes.
- [x] If this touches `packages/` or `telemetry/`, I've flagged it for extra review — it does not.
- [ ] Version bumped in `.claude-plugin/plugin.json` — **not bumped.** `scripts/` never ships and the bundle is byte-identical.
