### PR TITLE
test(stacks): stack-profile completeness check in CI (#50)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ a release is only "live" for users once that is bumped and published.
 
 ## [Unreleased]
 ### Added
+- **Stack-profile completeness check (CI).** `scripts/stack-profiles.test.mjs` asserts every `instructions/stacks/<id>.md` carries the sections the documented format requires (Detect / Commands / Coverage / E2E / Conventions & gotchas), each non-empty — so an incomplete or malformed profile fails CI instead of silently degrading the kit for that stack. First (completeness) half of per-stack validation; real end-to-end sample-repo runs are a later step.
 - **Azure DevOps as a PR host.** `create-pr` can now open the PR on Azure DevOps via `az repos pr create` (Azure CLI + `azure-devops` extension), alongside GitHub / GitLab / Bitbucket. The `prs_created` telemetry detector counts it too. Closes the gap where the tracker supported `azure` but PR creation didn't. Kit → **0.19.7**.
 - **CI (GitHub Actions).** `.github/workflows/ci.yml` runs on every push to `main` and every PR: validate the bundle, `node --test`, then rebuild and `git diff --exit-code` to assert the committed bundle/manifests are in sync. Catches skip-build drift, stale manifests, and contract divergence automatically — the failure modes we previously found by hand.
 - **Contract-parity guard.** `scripts/contract-parity.test.mjs` asserts the two `contract.v1.json` copies (client + relay) are byte-identical, so a property added to one but not the other can't silently drift.

--- a/scripts/stack-profiles.test.mjs
+++ b/scripts/stack-profiles.test.mjs
@@ -1,0 +1,49 @@
+/*
+ * Structural lint for the stack profiles in instructions/stacks/. Zero-dep (node:test).
+ *
+ * The profiles are the kit's "iteration zero" per stack — the commands a session falls
+ * back to when the consuming repo is silent. A profile missing its coverage or e2e
+ * section silently degrades the kit for that stack. This asserts every profile carries
+ * the sections the format (instructions/stacks/README.md) documents, each with content,
+ * so an incomplete or malformed profile fails CI instead of shipping.
+ *
+ * This is the completeness half of #50; real end-to-end per-stack validation (sample
+ * repos exercising the gates) is a separate, larger step.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const STACKS = join(ROOT, 'instructions', 'stacks');
+
+// The sections documented in instructions/stacks/README.md → "Profile format".
+const REQUIRED = ['Detect', 'Commands', 'Coverage', 'E2E', 'Conventions & gotchas'];
+
+const profiles = readdirSync(STACKS).filter((f) => f.endsWith('.md') && f !== 'README.md');
+
+test('there is at least one stack profile', () => {
+  assert.ok(profiles.length > 0, 'no stack profiles found in instructions/stacks/');
+});
+
+for (const file of profiles) {
+  test(`stack profile ${file} is well-formed`, () => {
+    const body = readFileSync(join(STACKS, file), 'utf8');
+
+    assert.match(body, /^# .+/m, `${file}: missing an H1 title (e.g. "# Node — stack profile")`);
+
+    const headings = [...body.matchAll(/^## (.+)$/gm)].map((m) => ({ name: m[1].trim(), start: m.index }));
+    const names = headings.map((h) => h.name);
+
+    for (const req of REQUIRED) {
+      const idx = names.indexOf(req);
+      assert.ok(idx !== -1, `${file}: missing required section "## ${req}"`);
+      const start = headings[idx].start;
+      const end = idx + 1 < headings.length ? headings[idx + 1].start : body.length;
+      const content = body.slice(start, end).replace(/^##[^\n]*\n?/, '').trim();
+      assert.ok(content.length > 0, `${file}: section "## ${req}" has no content`);
+    }
+  });
+}


### PR DESCRIPTION
First slice of #50. The stack profiles are the kit's "iteration zero" per stack — a profile missing its Coverage or E2E section silently degrades the kit there. This adds a structural lint so that fails CI instead.

## What it checks
`scripts/stack-profiles.test.mjs` (zero-dep `node:test`) asserts, for every `instructions/stacks/<id>.md`:
- an H1 title, and
- each documented section present **and non-empty**: `Detect`, `Commands`, `Coverage`, `E2E`, `Conventions & gotchas` (per `instructions/stacks/README.md`).

Verified it catches a real omission: deleting a profile's `## Coverage` section fails with `"<file>: missing required section \"## Coverage\""`.

## Scope
This is the **completeness** half of #50. Real end-to-end validation (sample repos exercising the gates + a CI matrix) is a larger, separate step — noted in the test header and #50.

## Verification
```
node --test scripts/*.test.mjs   # 30/30 (12 new)
node scripts/validate-codex-plugin.mjs   # ✓
```
No shipped content changed — no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)