### PR TITLE
fix(skills): verify tracker and PR label/assignee writes by read-back

### DIFF
--- a/plugins/fullstack-dev-kit/skills/create-pr/SKILL.md
+++ b/plugins/fullstack-dev-kit/skills/create-pr/SKILL.md
@@ -78,7 +78,7 @@ Use the repo's PR template instead if one exists (`.github/PULL_REQUEST_TEMPLATE
 
 **AI traceability metadata**, best effort after creation:
 
-- Add an `ai-generated` label/tag to the PR when the host supports it — GitHub: `gh pr edit <url> --add-label ai-generated` (create it once with `gh label create ai-generated --color 8A2BE2` if missing); Bitbucket/GitLab: skip or use the host's equivalent. If not possible, skip silently — the badge and footer already carry the signal.
+- Add an `ai-generated` label/tag to the PR when the host supports it — GitHub: `gh pr edit <url> --add-label ai-generated` (create it once with `gh label create ai-generated --color 8A2BE2` if missing), then **verify it stuck** with `gh pr view <url> --json labels` — `gh pr edit` can error without applying anything on repos whose org ever used classic Projects; on a miss, apply via REST: `gh api repos/<owner>/<repo>/issues/<pr-number>/labels -f "labels[]=ai-generated"`. Bitbucket/GitLab: skip or use the host's equivalent. If not possible, skip silently — the badge and footer already carry the signal.
 
 ## After creation
 

--- a/plugins/fullstack-dev-kit/skills/issue-update/SKILL.md
+++ b/plugins/fullstack-dev-kit/skills/issue-update/SKILL.md
@@ -56,6 +56,7 @@ Move the item to the team's review status. **Never hardcode transition/state IDs
 - Comment: `gh issue comment <number> --repo <owner/name> --body-file -`.
 - Owner: `gh issue edit <number> --add-assignee @me` if unassigned.
 - "Review status": GitHub issues have no workflow states — apply the label the team uses (e.g. `in-review`) via `gh issue edit --add-label`, and/or move it in the project board if one is configured. Persist the label under `tracker.reviewState`.
+- **Verify both writes by read-back — never trust the exit code.** `gh issue edit` can fail while applying nothing (its project-fields prefetch trips on repos whose org ever used classic Projects), which is the worst shape for the step the story is not done without. After editing, run `gh issue view <number> --json assignees,labels` and confirm the assignee and label actually landed; on a miss, apply via REST instead — `gh api repos/<owner>/<repo>/issues/<number>/assignees -f "assignees[]=<login>"` / `gh api repos/<owner>/<repo>/issues/<number>/labels -f "labels[]=<label>"` — and report which path worked.
 
 ### Azure DevOps (`type: "azure"`)
 - Comment and assign via the Azure DevOps MCP or REST / `az boards`.

--- a/skills/create-pr/SKILL.md
+++ b/skills/create-pr/SKILL.md
@@ -78,7 +78,7 @@ Use the repo's PR template instead if one exists (`.github/PULL_REQUEST_TEMPLATE
 
 **AI traceability metadata**, best effort after creation:
 
-- Add an `ai-generated` label/tag to the PR when the host supports it — GitHub: `gh pr edit <url> --add-label ai-generated` (create it once with `gh label create ai-generated --color 8A2BE2` if missing); Bitbucket/GitLab: skip or use the host's equivalent. If not possible, skip silently — the badge and footer already carry the signal.
+- Add an `ai-generated` label/tag to the PR when the host supports it — GitHub: `gh pr edit <url> --add-label ai-generated` (create it once with `gh label create ai-generated --color 8A2BE2` if missing), then **verify it stuck** with `gh pr view <url> --json labels` — `gh pr edit` can error without applying anything on repos whose org ever used classic Projects; on a miss, apply via REST: `gh api repos/<owner>/<repo>/issues/<pr-number>/labels -f "labels[]=ai-generated"`. Bitbucket/GitLab: skip or use the host's equivalent. If not possible, skip silently — the badge and footer already carry the signal.
 
 ## After creation
 

--- a/skills/issue-update/SKILL.md
+++ b/skills/issue-update/SKILL.md
@@ -56,6 +56,7 @@ Move the item to the team's review status. **Never hardcode transition/state IDs
 - Comment: `gh issue comment <number> --repo <owner/name> --body-file -`.
 - Owner: `gh issue edit <number> --add-assignee @me` if unassigned.
 - "Review status": GitHub issues have no workflow states — apply the label the team uses (e.g. `in-review`) via `gh issue edit --add-label`, and/or move it in the project board if one is configured. Persist the label under `tracker.reviewState`.
+- **Verify both writes by read-back — never trust the exit code.** `gh issue edit` can fail while applying nothing (its project-fields prefetch trips on repos whose org ever used classic Projects), which is the worst shape for the step the story is not done without. After editing, run `gh issue view <number> --json assignees,labels` and confirm the assignee and label actually landed; on a miss, apply via REST instead — `gh api repos/<owner>/<repo>/issues/<number>/assignees -f "assignees[]=<login>"` / `gh api repos/<owner>/<repo>/issues/<number>/labels -f "labels[]=<label>"` — and report which path worked.
 
 ### Azure DevOps (`type: "azure"`)
 - Comment and assign via the Azure DevOps MCP or REST / `az boards`.


### PR DESCRIPTION
## What changes

The three `gh … edit` writes in the delivery tail are now verified by read-back, with a REST fallback when the edit didn't land:

- `skills/issue-update/SKILL.md` — after assigning and labeling, `gh issue view <number> --json assignees,labels` confirms both actually landed; on a miss, apply via `gh api …/assignees` / `…/labels` and report which path worked.
- `skills/create-pr/SKILL.md` — after `gh pr edit --add-label ai-generated`, `gh pr view <url> --json labels` confirms it stuck; on a miss, `gh api …/labels`.

Prompts only. Bundle regenerated (`node scripts/build-codex-plugin.mjs`); validator and all 30 tests pass; rebuild is a no-op on the committed tree.

## Why

`gh pr edit` / `gh issue edit` prefetch the item's project fields over GraphQL before writing. On a repo whose org ever used classic Projects, that prefetch can trip on the deprecated fields: the CLI errors **without applying the edit**. Observed in the field against a production GitHub org; the same class applies to `gh issue edit`. It is the worst shape of failure for this step in particular — the kit's own rule is *"The story is not done until the tracker reflects it"*, and this was the one step that reported the tracker updated without ever reading the tracker back. The fix extends the principle the gates already follow — verify by observation, never by exit code — to the writes the kit calls load-bearing.

## How it was verified

```
node scripts/build-codex-plugin.mjs      # bundle resynced, validator ✓
node --test scripts/*.test.mjs           # 30 pass, 0 fail
node scripts/validate-codex-plugin.mjs   # ✓ in-sync, self-contained
```

Closes #57.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) via the
fullstack-dev-kit plugin workflow. Human-reviewed before submission.
