### PR TITLE
fix(stacks): fail report-listed files that carry no statement metrics

### DIFF
--- a/scripts/check-clover.mjs
+++ b/scripts/check-clover.mjs
@@ -13,8 +13,11 @@
  * class-level one). Branch coverage comes from conditionals when the driver
  * reports them; PHPUnit under PCOV always writes conditionals="0" (branch
  * data needs Xdebug path coverage), and "the driver reported none" is n/a,
- * not a failure — stated plainly, never fabricated. Attribute parsing is
- * order-independent: Clover writers do not agree on attribute order.
+ * not a failure — stated plainly, never fabricated. The opposite asymmetry
+ * also holds: a <file> that appears in the report without statement metrics
+ * FAILS rather than being skipped — absence of measurement is not a pass,
+ * and a report that stops measuring must not stay green. Attribute parsing
+ * is order-independent: Clover writers do not agree on attribute order.
  */
 import { readFileSync } from 'node:fs';
 
@@ -23,7 +26,12 @@ export function parseClover(xml) {
   const re = /<file name="([^"]+)"[^>]*>([\s\S]*?)<\/file>/g;
   for (const [, name, body] of xml.matchAll(re)) {
     const metrics = [...body.matchAll(/<metrics([^>]*?)\/?>/g)];
-    if (metrics.length === 0) continue;
+    // Present but unmeasured is a finding, not a skip: emit the file with
+    // null metrics so the verdict fails it (lines: null never passes a bar).
+    if (metrics.length === 0) {
+      files.push({ name, lines: null, branches: null });
+      continue;
+    }
     const attrs = metrics[metrics.length - 1][1];
     const attr = (key) => {
       const found = attrs.match(new RegExp(`\\b${key}="(\\d+)"`));
@@ -31,7 +39,10 @@ export function parseClover(xml) {
     };
     const statements = attr('statements');
     const covered = attr('coveredstatements');
-    if (statements === null || covered === null) continue;
+    if (statements === null || covered === null) {
+      files.push({ name, lines: null, branches: null });
+      continue;
+    }
     const conditionals = attr('conditionals') ?? 0;
     const coveredConditionals = attr('coveredconditionals') ?? 0;
     files.push({
@@ -47,7 +58,9 @@ export function parseClover(xml) {
 export function verdicts(files, bar) {
   return files.map((file) => ({
     ...file,
-    pass: file.lines >= bar && (file.branches === null || file.branches >= bar),
+    // lines === null means the report carries no statement metrics for the
+    // file — never passable, at any bar.
+    pass: file.lines !== null && file.lines >= bar && (file.branches === null || file.branches >= bar),
   }));
 }
 
@@ -67,10 +80,9 @@ if (invokedDirectly) {
     process.exit(1);
   }
   for (const row of rows) {
+    const lines = row.lines === null ? 'unmeasured (no statement metrics)' : `${row.lines.toFixed(1)}%`;
     const branches = row.branches === null ? 'n/a (driver reports none)' : `${row.branches.toFixed(1)}%`;
-    console.log(
-      `${row.pass ? 'PASS' : 'FAIL'}  lines ${row.lines.toFixed(1)}%  branches ${branches}  ${row.name}`,
-    );
+    console.log(`${row.pass ? 'PASS' : 'FAIL'}  lines ${lines}  branches ${branches}  ${row.name}`);
   }
   const failed = rows.filter((row) => !row.pass);
   if (failed.length > 0) {

--- a/scripts/check-clover.test.mjs
+++ b/scripts/check-clover.test.mjs
@@ -54,3 +54,26 @@ test('verdicts fail exactly the files below the bar', () => {
 test('an empty or non-Clover document yields no rows', () => {
   assert.deepEqual(parseClover('<coverage/>'), []);
 });
+
+test('a file present without statement metrics fails, at any bar', () => {
+  // Absence of measurement is not a pass: a report that lists the file but
+  // stops measuring it must not leave the gate green.
+  const xml = `<coverage><project>
+    <file name="/app/src/NoMetrics.php"><line num="1" type="stmt" count="0"/></file>
+    <file name="/app/src/HalfMetrics.php"><metrics loc="5" methods="1" coveredmethods="1"/></file>
+    <file name="/app/src/Measured.php"><metrics statements="4" coveredstatements="4" conditionals="0" coveredconditionals="0"/></file>
+  </project></coverage>`;
+  const files = parseClover(xml);
+  assert.deepEqual(
+    files.map((file) => [file.name.split('/').pop(), file.lines]),
+    [
+      ['NoMetrics.php', null],
+      ['HalfMetrics.php', null],
+      ['Measured.php', 100],
+    ],
+  );
+  for (const bar of [95, 0]) {
+    const rows = verdicts(files, bar);
+    assert.deepEqual(rows.map((row) => row.pass), [false, false, true], `bar ${bar}`);
+  }
+});


### PR DESCRIPTION
The promised follow-up to the second non-blocking note on #59:

> `check-clover.mjs` silently `continue`s a `<file>` whose metrics lack `statements` rather than failing it — low-risk (PHPUnit always emits them), but counting skipped-but-present files would be safer.

## What changes

Present-but-unmeasured is now a finding, not a skip. A `<file>` that appears in the report with no `<metrics>` element at all, or whose metrics carry no statement counters, is emitted with `lines: null` — which never passes, at any bar — and the CLI reports it as `FAIL  lines unmeasured (no statement metrics)`. A report that lists a file but stops measuring it can no longer leave the gate green.

The honest-n/a behaviour for branch data under PCOV is unchanged, and the header comment now states both sides of what would otherwise look like a contradiction: *branch data the driver never produces is n/a; a file the report lists but stops measuring is a failure.*

Covered by a test driving all three shapes (no metrics element / metrics without statement counters / fully measured) at two different bars.

## How it was verified

```
node --test scripts/*.test.mjs        # 35 pass (1 new), 0 fail
node scripts/validate-codex-plugin.mjs # ✓
```

No changelog entry: `scripts/` is repo-only, per the distinction drawn in the #59 review.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) via the
fullstack-dev-kit plugin workflow. Human-reviewed before submission.
