### PR TITLE
docs(readme): stacks + release badges, per-host install table up top

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # claude-dev-kit
 
 [![CI](https://github.com/theam/claude-dev-kit/actions/workflows/ci.yml/badge.svg)](https://github.com/theam/claude-dev-kit/actions/workflows/ci.yml)
+[![Stacks](https://github.com/theam/claude-dev-kit/actions/workflows/stacks.yml/badge.svg)](https://github.com/theam/claude-dev-kit/actions/workflows/stacks.yml)
+[![Release](https://img.shields.io/github/v/release/theam/claude-dev-kit)](https://github.com/theam/claude-dev-kit/releases)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 
 An open-source [Claude Code](https://code.claude.com) plugin by [The Agile Monkeys](https://www.theagilemonkeys.com): a **stack-agnostic issue-to-PR workflow** with enforced quality gates. Also runs on **OpenAI Codex**, **Cursor**, and other [Agent Plugins 1.0.0](https://agent-plugins.org) clients.
@@ -38,14 +40,16 @@ npm create @theagilemonkeys/dev-kit
 
 Interactive setup — tracker, Figma, telemetry consent, org — then it installs the plugin for whichever agents you have (Claude Code / Codex / Cursor). Full options in [Installing in Claude Code](#installing-in-claude-code).
 
-**On OpenAI Codex** you can also install it natively:
+**Or install directly on your host:**
 
-```bash
-codex plugin marketplace add theam/claude-dev-kit
-codex plugin add fullstack-dev-kit@claude-dev-kit
-```
+| Host | One-liner |
+|---|---|
+| **Claude Code** | `claude plugin marketplace add theam/claude-dev-kit && claude plugin install fullstack-dev-kit@claude-dev-kit` |
+| **OpenAI Codex** | `codex plugin marketplace add theam/claude-dev-kit && codex plugin add fullstack-dev-kit@claude-dev-kit` — then `$work-story PROJ-1234` |
+| **Cursor** | the wizard above — it detects Cursor and drops the portable plugin into `~/.cursor/plugins/local/` ([details](#cursor--no-git-url-installer-yet)) |
+| **Copilot (VS Code)** | Command Palette → **"Chat: Install Plugin From Source"** → `https://github.com/theam/claude-dev-kit` |
 
-Then run `$work-story PROJ-1234` (or any single skill, e.g. `$pr-review`). More — including Cursor and Copilot — in [Also runs on Codex, Cursor & Copilot](#also-runs-on-codex-cursor--copilot-experimental).
+More — including which hosts are validated end to end — in [Also runs on Codex, Cursor & Copilot](#also-runs-on-codex-cursor--copilot-experimental).
 
 ## Stack-agnostic by design
 


### PR DESCRIPTION
Addresses #47 — the two checkboxes that are actionable today, with an honest accounting of the other two:

- ✅ **Badges** — [Stacks](https://github.com/theam/claude-dev-kit/actions/workflows/stacks.yml) and latest-release badges join the existing CI + License pair, so the stack matrix's health and the current version are visible at a glance.
- ✅ **One-liner install per host, up top** — the Codex-only quick block becomes a four-host table (Claude Code / Codex / Cursor / Copilot), each row using exactly the command its detail section already documents, and linking there. The wizard stays first as the recommended path.
- ⛔ **OpenAI directory link / "Try in ChatGPT"** — can't be added yet by anyone: per `SUBMISSION.md` the listing is submission-ready but unpublished, blocked only on the Apps Management role grant. One-line addition the day it goes live.
- ✅-ish **Demo GIF** — the README already embeds a demo *video* of the ticket → PR flow (the yardflow run), which seems to satisfy the intent; left untouched. If a lighter inline GIF is still wanted, happy to wire one in from a recording.
