### PR TITLE
docs(submission): verified Cursor + Copilot marketplace steps and status

### DIFF
--- a/SUBMISSION.md
+++ b/SUBMISSION.md
@@ -35,23 +35,21 @@ Start with **OpenAI** (largest reach: Codex + ChatGPT); Cursor and VS Code can f
 ### Cursor submission — exact steps (verified Aug 2026)
 
 1. **Manifest** — Cursor's publish flow accepts an Agent Plugin with a root
-   `plugin.json`, or a Cursor Plugin with `.cursor-plugin/plugin.json`. **Our state:** the
-   repo root carries `.cursor-plugin/marketplace.json` (a *marketplace* listing
-   `plugins/fullstack-dev-kit`), and the portable root `plugin.json` lives inside
-   `plugins/fullstack-dev-kit/` — not at the repo root. ❓ **Confirm at submission** whether
-   the publish form accepts a marketplace repo; if it wants a single plugin manifest, the
-   options are a root-level `.cursor-plugin/plugin.json` pointing at the bundle, or asking
-   Cursor which shape they prefer. (Teams can already import the repo as a marketplace —
-   README documents that path.)
+   `plugin.json`, or a Cursor Plugin with `.cursor-plugin/plugin.json`. **Resolved in
+   practice:** the publish form **accepted** our root `.cursor-plugin/marketplace.json` →
+   subdir plugin (`plugins/fullstack-dev-kit`) as submitted — no root single-plugin
+   manifest was needed. (Teams can also import the repo as a marketplace — README
+   documents that path.)
 2. **Name rules** — lowercase kebab-case, alphanumerics/hyphens/periods, starts and ends
    alphanumeric. `fullstack-dev-kit` ✅ complies.
 3. **Logo** — must be committed to the repo and referenced by **relative path** (Cursor
    renders it from `raw.githubusercontent.com`). Brand icons are in `assets/` ✅ — verify the
    manifest references them relatively, not by absolute URL.
-4. **Submit** — ⛔ **owner-only**: only the repo owner can submit. Visit
-   `cursor.com/marketplace/publish` and submit the public repository link.
+4. **Submit** — owner-only; ✅ **done**: the owner submitted the public repository link
+   at `cursor.com/marketplace/publish`.
 5. **Review** — every plugin is manually reviewed before listing, and **every update is
    re-reviewed**. All marketplace plugins must be open source (we are, Apache-2.0).
+   **Status: ⏳ in Cursor's manual review — submitted, not yet listed.**
 
 ### VS Code / Copilot (`@agentPlugins`) — steps + status (verified Aug 2026)
 
@@ -63,13 +61,15 @@ and **`github/awesome-copilot`**. Getting listed in awesome-copilot is therefore
 account involved. (Users can also add this repo itself as a marketplace via the
 `chat.plugins.marketplaces` setting — the README documents install-from-source today.)
 
-**Status:** submission was attempted **2026-08-20** — awesome-copilot issues
-[#2730](https://github.com/github/awesome-copilot/issues/2730) / #2731, filed via CLI and
-closed by the submitter to redo it "via the official web form so the external-plugin
-intake labels/automation are applied correctly." As of 2026-08-29 `fullstack-dev-kit` is
-not yet listed there and no new intake issue exists, so ⛔ the **web-form external-plugin
-resubmission is the open action** (owner: the original submitter, referencing
-`theam/claude-dev-kit` + path `plugins/fullstack-dev-kit`, as #2730 did).
+**Status: submitted and declined — no open action.** The CLI-filed intake
+([#2730](https://github.com/github/awesome-copilot/issues/2730), 2026-08-20) was closed in
+favor of the **web-form resubmission (#2731)**, which passed automated intake the same day
+and was then **rejected by a maintainer on 2026-08-26 on curation grounds** — in their
+words, the skills are "either overly simplistic … or replicate functionality built into
+the harness (such as the issue/PR skills)." Copilot users still get the kit today via
+**install-from-source** (verified; the README documents it), and `chat.plugins.marketplaces`
+can point at this repo directly. Re-approaching the directory would mean addressing the
+curation feedback first, not resubmitting as-is.
 
 ## Requirements checklist
 
@@ -130,5 +130,5 @@ URL, no `.well-known/openai-apps-challenge` domain verification, no tool-annotat
 3. ~~Design: logo / composerIcon / brandColor / screenshots~~ — done. Optional polish: crop chrome / anonymize the screenshots (drop-in, same filenames).
 4. ~~Decide `termsOfServiceURL` / website~~ — done (`LICENSE`; website = repo; legal can swap later).
 5. **Kit:** ✅ `interface` wired (brand icons + color) and validated. Package is **submission-ready** — once the Apps Management role is granted, submit skills-only via the portal (Cursor / VS Code to follow).
-6. **Cursor (owner):** submit the repo link at `cursor.com/marketplace/publish` — resolving the manifest-location question in the Cursor section first.
-7. **Copilot (owner):** redo the awesome-copilot **external-plugin web-form submission** (the 08-20 CLI-filed intake #2730 was closed for exactly this; nothing has been resubmitted since).
+6. **Cursor:** ✅ submitted (marketplace repo accepted as-is) — ⏳ awaiting Cursor's manual review; nothing to do until they answer.
+7. **Copilot:** ⛔ awesome-copilot **declined 2026-08-26** (curation: skills judged too simple / overlapping the harness's built-ins). Install-from-source remains the documented path; a future re-approach starts from the curation feedback, not a resubmission.

--- a/SUBMISSION.md
+++ b/SUBMISSION.md
@@ -14,8 +14,8 @@ The plugin is already a valid **Agent Plugins 1.0.0** package (portable root `pl
 | Directory | Covers | How to submit |
 | --- | --- | --- |
 | **OpenAI Plugins Directory** | Codex + ChatGPT | Web submission portal (`developers.openai.com/plugins/deploy/submission`) |
-| **Cursor marketplace** | Cursor | `cursor.com/marketplace` (official) or community `cursor.directory` |
-| **VS Code Extensions** | GitHub Copilot / VS Code | Package + publish so it surfaces under `@agentPlugins` |
+| **Cursor marketplace** | Cursor | Owner submits the public repo link at `cursor.com/marketplace/publish` (steps below) |
+| **VS Code / Copilot** | GitHub Copilot / VS Code / Copilot CLI + app | List in `github/awesome-copilot`, a default marketplace — plugins then surface under `@agentPlugins` (steps + status below) |
 
 Start with **OpenAI** (largest reach: Codex + ChatGPT); Cursor and VS Code can follow.
 
@@ -31,6 +31,45 @@ Start with **OpenAI** (largest reach: Codex + ChatGPT); Cursor and VS Code can f
    - **Global** — target countries/regions.
    - **Submit** — release notes + policy attestations → **Submit for Review**.
 4. **After approval** — the developer publishes; it then appears in the Directory.
+
+### Cursor submission — exact steps (verified Aug 2026)
+
+1. **Manifest** — Cursor's publish flow accepts an Agent Plugin with a root
+   `plugin.json`, or a Cursor Plugin with `.cursor-plugin/plugin.json`. **Our state:** the
+   repo root carries `.cursor-plugin/marketplace.json` (a *marketplace* listing
+   `plugins/fullstack-dev-kit`), and the portable root `plugin.json` lives inside
+   `plugins/fullstack-dev-kit/` — not at the repo root. ❓ **Confirm at submission** whether
+   the publish form accepts a marketplace repo; if it wants a single plugin manifest, the
+   options are a root-level `.cursor-plugin/plugin.json` pointing at the bundle, or asking
+   Cursor which shape they prefer. (Teams can already import the repo as a marketplace —
+   README documents that path.)
+2. **Name rules** — lowercase kebab-case, alphanumerics/hyphens/periods, starts and ends
+   alphanumeric. `fullstack-dev-kit` ✅ complies.
+3. **Logo** — must be committed to the repo and referenced by **relative path** (Cursor
+   renders it from `raw.githubusercontent.com`). Brand icons are in `assets/` ✅ — verify the
+   manifest references them relatively, not by absolute URL.
+4. **Submit** — ⛔ **owner-only**: only the repo owner can submit. Visit
+   `cursor.com/marketplace/publish` and submit the public repository link.
+5. **Review** — every plugin is manually reviewed before listing, and **every update is
+   re-reviewed**. All marketplace plugins must be open source (we are, Apache-2.0).
+
+### VS Code / Copilot (`@agentPlugins`) — steps + status (verified Aug 2026)
+
+Agent Plugins 1.0 went GA in VS Code, Copilot CLI, and the Copilot app on **2026-08-12**
+(GitHub changelog), on all Copilot plans. Discovery: users search `@agentPlugins` in the
+Extensions view, which browses the configured marketplaces — by default `copilot-plugins`
+and **`github/awesome-copilot`**. Getting listed in awesome-copilot is therefore the
+"surfaces under `@agentPlugins`" box, with no VSIX packaging or Azure DevOps publisher
+account involved. (Users can also add this repo itself as a marketplace via the
+`chat.plugins.marketplaces` setting — the README documents install-from-source today.)
+
+**Status:** submission was attempted **2026-08-20** — awesome-copilot issues
+[#2730](https://github.com/github/awesome-copilot/issues/2730) / #2731, filed via CLI and
+closed by the submitter to redo it "via the official web form so the external-plugin
+intake labels/automation are applied correctly." As of 2026-08-29 `fullstack-dev-kit` is
+not yet listed there and no new intake issue exists, so ⛔ the **web-form external-plugin
+resubmission is the open action** (owner: the original submitter, referencing
+`theam/claude-dev-kit` + path `plugins/fullstack-dev-kit`, as #2730 did).
 
 ## Requirements checklist
 
@@ -91,3 +130,5 @@ URL, no `.well-known/openai-apps-challenge` domain verification, no tool-annotat
 3. ~~Design: logo / composerIcon / brandColor / screenshots~~ — done. Optional polish: crop chrome / anonymize the screenshots (drop-in, same filenames).
 4. ~~Decide `termsOfServiceURL` / website~~ — done (`LICENSE`; website = repo; legal can swap later).
 5. **Kit:** ✅ `interface` wired (brand icons + color) and validated. Package is **submission-ready** — once the Apps Management role is granted, submit skills-only via the portal (Cursor / VS Code to follow).
+6. **Cursor (owner):** submit the repo link at `cursor.com/marketplace/publish` — resolving the manifest-location question in the Cursor section first.
+7. **Copilot (owner):** redo the awesome-copilot **external-plugin web-form submission** (the 08-20 CLI-filed intake #2730 was closed for exactly this; nothing has been resubmitted since).


### PR DESCRIPTION
Addresses #48 — the two channels the issue names get the same exact-steps treatment `SUBMISSION.md` already gives OpenAI, from a verification pass done today (2026-08-29). The actual submissions stay owner-gated (Cursor's form is owner-only; the awesome-copilot redo belongs to the original submitter), so this PR ships everything an outside contributor can: the verified path, the package-compliance check, and the true current status.

**Cursor** (per [cursor.com/docs/reference/plugins](https://cursor.com/docs/reference/plugins) and the [marketplace announcement](https://cursor.com/blog/marketplace)):
- Submission = owner submits the public repo link at `cursor.com/marketplace/publish`; every listing **and every update** is manually reviewed; marketplace plugins must be open source (we are).
- `fullstack-dev-kit` ✅ complies with the naming rules; logos are committed in `assets/` (relative-path reference is the requirement to double-check).
- One real question flagged rather than guessed: our repo root carries `.cursor-plugin/marketplace.json` (a *marketplace*), while the portable root `plugin.json` lives inside `plugins/fullstack-dev-kit/` — whether the publish form accepts a marketplace repo or wants a root manifest needs confirming at submission time.

**VS Code / Copilot** (per the [GitHub changelog, 2026-08-12](https://github.blog/changelog/2026-08-12-agent-plugins-1-0-in-vs-code-copilot-cli-and-the-copilot-app/) and [VS Code docs](https://code.visualstudio.com/docs/agent-customization/agent-plugins)):
- Agent Plugins 1.0 is GA on all Copilot plans; `@agentPlugins` browses the configured marketplaces, and **`github/awesome-copilot` is one of the two defaults** — so listing there *is* the "surfaces under `@agentPlugins`" checkbox, no VSIX or publisher account involved.
- Status honestly recorded: the 08-20 intake ([#2730](https://github.com/github/awesome-copilot/issues/2730)) was closed to redo via the official web form, and as of today `fullstack-dev-kit` isn't listed and no new intake exists — the web-form resubmission is the one open action, and it's yours to fire whenever you're ready.

The channels table and Next actions are updated to match. Happy to adjust anything — and if it helps, I can prep the awesome-copilot form answers from #2730's body so the redo is a two-minute paste.
