### PR TITLE
docs(readme): clarify stack profiles & overrides are host-agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ Either way, a skipped gate is **reported, never hidden**.
 
 ## Stack-agnostic by design
 
-The kit carries **no assumptions about language, framework, or test runner**. It reads everything stack-specific — build/test/lint/coverage commands, architecture conventions, and any implementer subagents — from the **consuming repo's `CLAUDE.md` and `.claude/`**, and detects conventions from the project when they aren't declared.
+The kit carries **no assumptions about language, framework, or test runner**. It reads everything stack-specific — build/test/lint/coverage commands, architecture conventions, and any implementer subagents — from the **consuming repo's instructions file (`CLAUDE.md`, or `AGENTS.md` on Codex) and `.claude/`**, and detects conventions from the project when they aren't declared.
 
-It ships **baseline "iteration zero" profiles** for common stacks in [`instructions/stacks/`](instructions/stacks/) — **node, angular, react, vue, python, dotnet, java, go, ruby, php, rust** — giving each one usable coverage/e2e/lint commands out of the box. Your `CLAUDE.md` always overrides them, and adding a stack is one markdown file (see [CONTRIBUTING](CONTRIBUTING.md#adding-or-improving-a-stack-profile)). These profiles are early and community-refined — treat an unlisted or unverified stack as "should work, help us confirm" rather than guaranteed.
+It ships **baseline "iteration zero" profiles** for common stacks in [`instructions/stacks/`](instructions/stacks/) — **node, angular, react, vue, python, dotnet, java, go, ruby, php, rust** — giving each one usable coverage/e2e/lint commands out of the box. These travel with the plugin, so they work the same on every host. Your project's instructions file always overrides them (`CLAUDE.md` on Claude, `AGENTS.md` on Codex, `.github/copilot-instructions.md` on Copilot), and adding a stack is one markdown file (see [CONTRIBUTING](CONTRIBUTING.md#adding-or-improving-a-stack-profile)). These profiles are early and community-refined — treat an unlisted or unverified stack as "should work, help us confirm" rather than guaranteed.
 
 It integrates with your tools through **adapters**, not hardcoded dependencies:
 


### PR DESCRIPTION
## What

The **Stack-agnostic by design** section read as if only `CLAUDE.md` overrides the shipped stack profiles — which is Claude-centric and inaccurate.

Two clarifications:

- The `instructions/stacks/` profiles **travel with the plugin**, so they work the same on Claude / Codex / Cursor / Copilot (confirmed: the Codex `work-story` skill loads `instructions/stacks/<id>.md` just like Claude).
- The **override** is whatever project-instructions file the host agent loads, not `CLAUDE.md` specifically:
  - `CLAUDE.md` on Claude
  - `AGENTS.md` on Codex
  - `.github/copilot-instructions.md` on Copilot

## Scope

Docs-only, one section reworded. No version bump / rebuild (README isn't bundled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)